### PR TITLE
Fix: Updated `Stripe` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/hashicorp/consul/api v1.33.4
 	github.com/hashicorp/nomad/api v0.0.0-20260314001232-211384eb84d3
 	github.com/shopspring/decimal v1.2.0
-	github.com/stretchr/testify v1.10.0
-	github.com/stripe/stripe-go/v84 v84.4.1
+	github.com/stretchr/testify v1.11.1
+	github.com/stripe/stripe-go/v85 v85.1.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
@@ -112,6 +112,6 @@ require (
 	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.7
 )

--- a/go.sum
+++ b/go.sum
@@ -355,10 +355,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stripe/stripe-go/v84 v84.4.1 h1:ixq1fG3y0k4OORVaN+LFAMBFaWiMrvKIcR9dSqT6gD8=
-github.com/stripe/stripe-go/v84 v84.4.1/go.mod h1:Z4gcKw1zl4geDG2+cjpSaJES9jaohGX6n7FP8/kHIqw=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stripe/stripe-go/v85 v85.1.0 h1:MywWUmgw9M7cnwFFch9cyLmRZuAiYM5cZ27JxH3a5/s=
+github.com/stripe/stripe-go/v85 v85.1.0/go.mod h1:5P+HGFenpWgak27T5Is6JMsmDfUC1yJnjhhmquz7kXw=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
 github.com/swaggo/gin-swagger v1.6.1 h1:Ri06G4gc9N4t4k8hekMigJ9zKTFSlqj/9paAQCQs7cY=

--- a/internal/payment-service/models/zones_subscriptions.go
+++ b/internal/payment-service/models/zones_subscriptions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v85"
 )
 
 type ZonesSubscriptions struct {

--- a/internal/payment-service/services/gem-balances/gem_balances.go
+++ b/internal/payment-service/services/gem-balances/gem_balances.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
-	"github.com/stripe/stripe-go/v84"
-	"github.com/stripe/stripe-go/v84/checkout/session"
-	"github.com/stripe/stripe-go/v84/webhook"
+	"github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v85/checkout/session"
+	"github.com/stripe/stripe-go/v85/webhook"
 
 	"github.com/FeedTheRealm-org/core-service/config"
 	"github.com/FeedTheRealm-org/core-service/internal/payment-service/models"

--- a/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
+++ b/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
@@ -12,13 +12,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
-	stripe "github.com/stripe/stripe-go/v84"
-	"github.com/stripe/stripe-go/v84/checkout/session"
-	"github.com/stripe/stripe-go/v84/customer"
-	"github.com/stripe/stripe-go/v84/invoice"
-	"github.com/stripe/stripe-go/v84/subscription"
-	"github.com/stripe/stripe-go/v84/subscriptionitem"
-	"github.com/stripe/stripe-go/v84/webhook"
+	stripe "github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v85/checkout/session"
+	"github.com/stripe/stripe-go/v85/customer"
+	"github.com/stripe/stripe-go/v85/invoice"
+	"github.com/stripe/stripe-go/v85/subscription"
+	"github.com/stripe/stripe-go/v85/subscriptionitem"
+	"github.com/stripe/stripe-go/v85/webhook"
 )
 
 type CannotExceedTotalSlotsError struct{}


### PR DESCRIPTION
Updated `Stripe` library for use `2026-04-22.dahlia` API version

## Checks

For **dev**, check the webhooks container if the version is like this

<img width="905" height="106" alt="image" src="https://github.com/user-attachments/assets/fb0e4f69-8fa2-4bce-bfa5-794d2043429e" />

If not, you should update the `STRIPE_API_KEY`, that get from dashboard and both webhooks secrets that come from containers (Both secrets are equals, so get from one).

For **prod**, check if the API version is updated to `2026-04-22.dahlia` (Go to `Webhooks` > `Resume`)

<img width="362" height="121" alt="image" src="https://github.com/user-attachments/assets/93cd1902-9e3d-4914-9213-355c38e1306a" />

