### PR TITLE
Bug-28: Get all worlds on Subscriptions

### DIFF
--- a/internal/world-service/controllers/world/world.go
+++ b/internal/world-service/controllers/world/world.go
@@ -192,6 +192,7 @@ func (c *worldController) GetWorld(ctx *gin.Context) {
 // @Security     BearerAuth
 // @Accept       json
 // @Produce      json
+// @Param        user_id query string false "Filter by owner user ID"
 // @Param        offset query int false "Offset for pagination"
 // @Param        limit query int false "Max hits per page"
 // @Param        filter query string false "Search filters"
@@ -207,9 +208,22 @@ func (c *worldController) GetWorldsList(ctx *gin.Context) {
 		return
 	}
 
+	userIdStr := ctx.Query("user_id")
 	offsetStr := ctx.Query("offset")
 	limitStr := ctx.Query("limit")
 	filter := ctx.Query("filter")
+
+	var userId uuid.UUID
+	if userIdStr != "" {
+		parseUserId, err := uuid.Parse(userIdStr)
+		if err != nil {
+			_ = ctx.Error(errors.NewBadRequestError("invalid user_id: " + userIdStr))
+			return
+		}
+		userId = parseUserId
+	} else {
+		userId = uuid.Nil
+	}
 
 	if offsetStr == "" || limitStr == "" {
 		_ = ctx.Error(errors.NewBadRequestError("offset and limit are required"))
@@ -227,7 +241,7 @@ func (c *worldController) GetWorldsList(ctx *gin.Context) {
 		return
 	}
 
-	worldsList, err := c.worldService.GetWorldsList(offset, limit, filter)
+	worldsList, err := c.worldService.GetWorldsList(offset, limit, filter, userId)
 	if err != nil {
 		if _, ok := err.(*world_errors.WorldInfoNotFound); ok {
 			_ = ctx.Error(errors.NewNotFoundError("world info not found"))

--- a/internal/world-service/repositories/world/repositories.go
+++ b/internal/world-service/repositories/world/repositories.go
@@ -35,7 +35,7 @@ type WorldRepository interface {
 	DeleteWorldData(worldID uuid.UUID) error
 
 	// GetWorldsList retrieves a paginated list of worlds.
-	GetWorldsList(offset int, limit int, filter string) ([]*models.WorldData, error)
+	GetWorldsList(offset int, limit int, filter string, userId uuid.UUID) ([]*models.WorldData, error)
 
 	// GetWorldZones retrieves available zones for a specific world.
 	GetWorldZones(worldID uuid.UUID) ([]*models.WorldZone, error)

--- a/internal/world-service/repositories/world/world.go
+++ b/internal/world-service/repositories/world/world.go
@@ -161,12 +161,16 @@ func (r *worldRepository) DeleteWorldData(worldID uuid.UUID) error {
 }
 
 // GetWorldsList retrieves a paginated list of worlds.
-func (r *worldRepository) GetWorldsList(offset int, limit int, filter string) ([]*models.WorldData, error) {
+func (r *worldRepository) GetWorldsList(offset int, limit int, filter string, userId uuid.UUID) ([]*models.WorldData, error) {
 	var worlds []*models.WorldData
 	query := r.db.Conn.Offset(offset).Limit(limit)
 
 	if filter != "" {
 		query = query.Where("name ILIKE ?", "%"+filter+"%")
+	}
+
+	if userId != uuid.Nil {
+		query = query.Where("user_id = ?", userId)
 	}
 
 	err := query.Find(&worlds).Error

--- a/internal/world-service/services/world/service.go
+++ b/internal/world-service/services/world/service.go
@@ -23,7 +23,7 @@ type WorldService interface {
 	DeleteWorld(worldID uuid.UUID, userId uuid.UUID) error
 
 	// GetWorldsList retrieves a paginated list of worlds.
-	GetWorldsList(offset int, limit int, filter string) ([]*models.WorldData, error)
+	GetWorldsList(offset int, limit int, filter string, userId uuid.UUID) ([]*models.WorldData, error)
 
 	// GetWorldZones retrieves zones for a specific world.
 	GetWorldZones(worldID uuid.UUID) ([]*models.WorldZone, error)

--- a/internal/world-service/services/world/world.go
+++ b/internal/world-service/services/world/world.go
@@ -133,8 +133,8 @@ func (cs *worldService) DeleteWorld(worldID uuid.UUID, userId uuid.UUID) error {
 	return nil
 }
 
-func (cs *worldService) GetWorldsList(offset int, limit int, filter string) ([]*models.WorldData, error) {
-	return cs.worldRepository.GetWorldsList(offset, limit, filter)
+func (cs *worldService) GetWorldsList(offset int, limit int, filter string, userId uuid.UUID) ([]*models.WorldData, error) {
+	return cs.worldRepository.GetWorldsList(offset, limit, filter, userId)
 }
 
 func (cs *worldService) GetWorldZones(worldID uuid.UUID) ([]*models.WorldZone, error) {

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -2710,6 +2710,12 @@ const docTemplate = `{
                 "summary": "List worlds",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "Filter by owner user ID",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Offset for pagination",
                         "name": "offset",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2703,6 +2703,12 @@
                 "summary": "List worlds",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "Filter by owner user ID",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Offset for pagination",
                         "name": "offset",

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -2244,6 +2244,10 @@ paths:
       - application/json
       description: Generates paginated meta-list of standard player-made worlds.
       parameters:
+      - description: Filter by owner user ID
+        in: query
+        name: user_id
+        type: string
       - description: Offset for pagination
         in: query
         name: offset


### PR DESCRIPTION
## Changes:

* Added optional `user_id` query parameter to `GET /world` to filter results by owner
* Updated `GetWorldsList` across the controller, service, repository, and interface to accept a `uuid.UUID` userId, applying a `WHERE user_id = ?` clause when non-nil
* Updated Swagger docs with the new `user_id` query parameter