### PR TITLE
Bug-22,28: Show subscription if you close checkout and handle if fail invoice on subs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ endif
 	$(MAKE) down
 .PHONY: seed
 
-
 seed-prod: # Seed the core-service production resources
 # Usage: make seed-prod ASSETS_BASE_PATH=xxx JWT_TOKEN=xxx [SEED_MODELS=false] [SEED_COSMETICS=false] [SEED_MATERIALS=false] [SEED_BOTS=false]
 ifndef ASSETS_BASE_PATH

--- a/internal/payment-service/services/gem-balances/gem_balances.go
+++ b/internal/payment-service/services/gem-balances/gem_balances.go
@@ -303,6 +303,14 @@ func (bs *gemBalancesService) HandleWebhook(payload []byte, signature string) er
 		}
 
 		logger.Logger.Info("Processing Stripe checkout session async payment failed event for session ID " + session.ID)
+	case "checkout.session.expired":
+		var session stripe.CheckoutSession
+		if err := json.Unmarshal(event.Data.Raw, &session); err != nil {
+			logger.Logger.Error("Failed to parse Stripe webhook event data: " + err.Error())
+			return err
+		}
+
+		logger.Logger.Info("Processing Stripe checkout session expired event for session ID " + session.ID)
 	default:
 		logger.Logger.Warn("Received unhandled Stripe webhook event type: " + event.Type)
 	}

--- a/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
+++ b/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
@@ -434,6 +434,15 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 			return err
 		}
 
+		_, err = subscription.Cancel(subscriptionId, &stripe.SubscriptionCancelParams{
+			InvoiceNow: stripe.Bool(false),
+			Prorate:    stripe.Bool(false),
+		})
+		if err != nil {
+			logger.Logger.Errorf("Failed to cancel Stripe subscription %s after payment failure: %v", subscriptionId, err)
+			return err
+		}
+
 		return nil
 	case "invoice.upcoming":
 		var invoice stripe.Invoice
@@ -460,33 +469,6 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		// TODO: call email service to notify the user
 		logger.Logger.Infof("Payment recovered for user %s — access restored", dbSub.UserID)
 
-		return nil
-	case "invoice.payment_action_required":
-		var invoice stripe.Invoice
-		if err := json.Unmarshal(event.Data.Raw, &invoice); err != nil {
-			return err
-		}
-
-		var subscriptionId = invoice.Parent.SubscriptionDetails.Subscription.ID
-		if subscriptionId == "" {
-			logger.Logger.Warn("invoice.payment_action_required received with no associated subscription, skipping")
-			return nil
-		}
-
-		dbSub, err := zs.repo.GetByStripeSubscriptionID(subscriptionId)
-		if err != nil {
-			logger.Logger.Warn("invoice.payment_action_required received for subscription ID with no DB record: " + subscriptionId)
-			return err
-		}
-
-		actionURL := invoice.HostedInvoiceURL
-
-		logger.Logger.Warnf(
-			"3DS authentication required for user %s, action URL: %s",
-			dbSub.UserID, actionURL,
-		)
-
-		// TODO: call email service to notify the user
 		return nil
 	default:
 		logger.Logger.Warnf("Unhandled Stripe webhook event type: %s", event.Type)

--- a/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
+++ b/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
@@ -3,6 +3,7 @@ package zones_subscriptions
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/FeedTheRealm-org/core-service/config"
@@ -42,8 +43,7 @@ func (zs *zoneSubscriptionService) CreateCheckoutSession(userID uuid.UUID, slots
 
 	sub, err := zs.repo.GetByUserID(userID)
 	if err == nil && sub != nil && sub.Status == stripe.SubscriptionStatusActive {
-		logger.Logger.Warnf("User %s already has an active subscription", userID)
-		return "", err
+		return "", fmt.Errorf("user %s already has an active subscription", userID)
 	}
 
 	sub, err = zs.ensureCustomer(userID, slots, sub)
@@ -250,6 +250,37 @@ func (zs *zoneSubscriptionService) CancelSubscription(userID uuid.UUID) (*models
 	return sub, nil
 }
 
+func (zs *zoneSubscriptionService) stopAllJobs(sub *models.ZonesSubscriptions) error {
+	logger.Logger.Infof("Stopping all jobs for user %s", sub.UserID)
+
+	if sub.UsedSlots != 0 {
+		logger.Logger.Warnf("User %s has %d used slots during stopAllJobs, resetting to 0", sub.UserID, sub.UsedSlots)
+
+		url := fmt.Sprintf("http://127.0.0.1:%d/world/internal/users/%s/stop-jobs", zs.conf.Server.Port, sub.UserID)
+		resp, err := http.Get(url)
+		if err != nil {
+			logger.Logger.Errorf("Failed to send stop-jobs internal request for user %s: %v", sub.UserID, err)
+			return err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		if resp.StatusCode != http.StatusOK {
+			logger.Logger.Errorf("Received non-OK status %d from stop-jobs internal request for user %s", resp.StatusCode, sub.UserID)
+			return fmt.Errorf("failed to stop jobs for user %s, status code: %d", sub.UserID, resp.StatusCode)
+		}
+
+		sub.UsedSlots = 0
+		if _, err := zs.repo.Update(sub); err != nil {
+			logger.Logger.Errorf("Failed to reset used slots for user %s during stopAllJobs: %v", sub.UserID, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature string) error {
 	event, err := webhook.ConstructEvent(payload, signature, zs.conf.Stripe.StripeSubscriptionsWebhookSecret)
 	if err != nil {
@@ -266,7 +297,7 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 
 		userIDStr, ok := stripeSub.Metadata["user_id"]
 		if !ok || userIDStr == "" {
-			return err
+			return fmt.Errorf("missing user_id in subscription metadata: %s", stripeSub.ID)
 		}
 		userID, err := uuid.Parse(userIDStr)
 		if err != nil {
@@ -282,6 +313,7 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		dbSub.Status = stripe.SubscriptionStatusActive
 		dbSub.NextBillingDate = zs.nextBillingDate()
 		dbSub.TotalSlots = int(stripeSub.Items.Data[0].Quantity)
+
 		amountDue, err := zs.getNextInvoiceAmount(dbSub.UserID)
 		if err != nil {
 			logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription creation: %v", dbSub.UserID, err)
@@ -303,7 +335,7 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 
 		userIDStr, ok := stripeSub.Metadata["user_id"]
 		if !ok || userIDStr == "" {
-			return err
+			return fmt.Errorf("missing user_id in subscription metadata: %s", stripeSub.ID)
 		}
 		userID, err := uuid.Parse(userIDStr)
 		if err != nil {
@@ -320,18 +352,25 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		dbSub.NextBillingDate = zs.nextBillingDate()
 		dbSub.TotalSlots = int(stripeSub.Items.Data[0].Quantity)
 
-		amountDue, err := zs.getNextInvoiceAmount(dbSub.UserID)
-		if err != nil {
-			logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription deletion: %v", dbSub.UserID, err)
-			return err
+		if stripeSub.Status == stripe.SubscriptionStatusActive {
+			amountDue, err := zs.getNextInvoiceAmount(dbSub.UserID)
+			if err != nil {
+				logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription update: %v", dbSub.UserID, err)
+				return err
+			}
+			dbSub.AmountDue = amountDue
 		}
-		dbSub.AmountDue = amountDue
 
 		if _, err = zs.repo.Update(dbSub); err != nil {
 			return err
 		}
 
-		logger.Logger.Infof("Handled subscription.updated for user %s", userID)
+		if stripeSub.Status == stripe.SubscriptionStatusPastDue {
+			logger.Logger.Warnf("Subscription past_due for user %s — restricting features", userID)
+			// TODO: call email service to notify the user
+		}
+
+		logger.Logger.Infof("Handled subscription.updated for user %s, status: %s", userID, stripeSub.Status)
 		return nil
 	case "customer.subscription.deleted":
 		var stripeSub stripe.Subscription
@@ -346,19 +385,108 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 
 		dbSub.Status = stripeSub.Status
 		dbSub.TotalSlots = int(stripeSub.Items.Data[0].Quantity)
-
-		amountDue, err := zs.getNextInvoiceAmount(dbSub.UserID)
-		if err != nil {
-			logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription deletion: %v", dbSub.UserID, err)
-			return err
-		}
-		dbSub.AmountDue = amountDue
+		dbSub.AmountDue = decimal.Zero
 
 		if _, err = zs.repo.Update(dbSub); err != nil {
 			return err
 		}
 
-		logger.Logger.Infof("Handled subscription.deleted for stripe sub %s", stripeSub.ID)
+		logger.Logger.Infof("Handled subscription.deleted for stripe sub %s, user %s", stripeSub.ID, dbSub.UserID)
+		return nil
+	case "invoice.payment_failed":
+		var invoice stripe.Invoice
+		if err := json.Unmarshal(event.Data.Raw, &invoice); err != nil {
+			return err
+		}
+
+		var subscriptionId = invoice.Parent.SubscriptionDetails.Subscription.ID
+		if subscriptionId == "" {
+			logger.Logger.Warn("invoice.payment_failed received with no associated subscription, skipping")
+			return nil
+		}
+
+		dbSub, err := zs.repo.GetByStripeSubscriptionID(subscriptionId)
+		if err != nil {
+			logger.Logger.Warn("invoice.payment_failed received for subscription ID with no DB record: " + subscriptionId)
+			return err
+		}
+
+		declineCode := ""
+		if invoice.Payments != nil {
+			for _, p := range invoice.Payments.Data {
+				if p.Payment != nil &&
+					p.Payment.PaymentIntent != nil &&
+					p.Payment.PaymentIntent.LastPaymentError != nil &&
+					p.Status == "open" {
+					declineCode = string(p.Payment.PaymentIntent.LastPaymentError.DeclineCode)
+				}
+			}
+		}
+
+		logger.Logger.Warnf(
+			"Payment failed for user %s, stripe sub %s, attempt #%d, decline code: %q",
+			dbSub.UserID, subscriptionId, invoice.AttemptCount, declineCode,
+		)
+
+		// TODO: call email service to notify the user
+		if err := zs.stopAllJobs(dbSub); err != nil {
+			logger.Logger.Errorf("Failed to run stopAllJobs: %v", err)
+			return err
+		}
+
+		return nil
+	case "invoice.upcoming":
+		var invoice stripe.Invoice
+		if err := json.Unmarshal(event.Data.Raw, &invoice); err != nil {
+			return err
+		}
+
+		var subscriptionId = invoice.Parent.SubscriptionDetails.Subscription.ID
+		if subscriptionId == "" {
+			logger.Logger.Warn("invoice.upcoming received with no associated subscription, skipping")
+			return nil
+		}
+
+		dbSub, err := zs.repo.GetByStripeSubscriptionID(subscriptionId)
+		if err != nil {
+			logger.Logger.Warn("invoice.upcoming received for subscription ID with no DB record: " + subscriptionId)
+			return err
+		}
+
+		dbSub.Status = stripe.SubscriptionStatusActive
+		if _, err = zs.repo.Update(dbSub); err != nil {
+			return err
+		}
+		// TODO: call email service to notify the user
+		logger.Logger.Infof("Payment recovered for user %s — access restored", dbSub.UserID)
+
+		return nil
+	case "invoice.payment_action_required":
+		var invoice stripe.Invoice
+		if err := json.Unmarshal(event.Data.Raw, &invoice); err != nil {
+			return err
+		}
+
+		var subscriptionId = invoice.Parent.SubscriptionDetails.Subscription.ID
+		if subscriptionId == "" {
+			logger.Logger.Warn("invoice.payment_action_required received with no associated subscription, skipping")
+			return nil
+		}
+
+		dbSub, err := zs.repo.GetByStripeSubscriptionID(subscriptionId)
+		if err != nil {
+			logger.Logger.Warn("invoice.payment_action_required received for subscription ID with no DB record: " + subscriptionId)
+			return err
+		}
+
+		actionURL := invoice.HostedInvoiceURL
+
+		logger.Logger.Warnf(
+			"3DS authentication required for user %s, action URL: %s",
+			dbSub.UserID, actionURL,
+		)
+
+		// TODO: call email service to notify the user
 		return nil
 	default:
 		logger.Logger.Warnf("Unhandled Stripe webhook event type: %s", event.Type)

--- a/internal/world-service/controllers/zones/controller.go
+++ b/internal/world-service/controllers/zones/controller.go
@@ -18,4 +18,7 @@ type ZonesController interface {
 
 	// DeactivateZone stops server orchestration for an active zone.
 	DeactivateZone(c *gin.Context)
+
+	// StopAllZonesForUser stops all active zones for a specific user.
+	StopAllJobsForUser(c *gin.Context)
 }

--- a/internal/world-service/controllers/zones/zones.go
+++ b/internal/world-service/controllers/zones/zones.go
@@ -309,3 +309,29 @@ func (c *zonesController) DeactivateZone(ctx *gin.Context) {
 
 	common_handlers.HandleBodilessResponse(ctx, http.StatusOK)
 }
+
+// StopAllJobsForUser godoc
+// @Summary      Stop all jobs for a user
+// @Description  Internal endpoint to stop all active zones and jobs for a specific user. Triggered internally by the payment service on subscription cancellation.
+// @Tags         world-service, internal
+// @Produce      json
+// @Param        user_id path string true "User UUID"
+// @Success      200  {string}  string "Acknowledge jobs stopped"
+// @Failure      400  {object} dtos.ErrorResponse
+// @Failure      500  {object} dtos.ErrorResponse
+// @Router       /world/internal/users/{user_id}/stop-jobs [get]
+func (c *zonesController) StopAllJobsForUser(ctx *gin.Context) {
+	userId, err := uuid.Parse(ctx.Param("user_id"))
+	if err != nil {
+		_ = ctx.Error(errors.NewBadRequestError("invalid user_id: " + ctx.Param("user_id")))
+		return
+	}
+
+	err = c.zonesService.StopAllZonesForUser(userId)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+
+	common_handlers.HandleBodilessResponse(ctx, http.StatusOK)
+}

--- a/internal/world-service/repositories/world/repositories.go
+++ b/internal/world-service/repositories/world/repositories.go
@@ -52,6 +52,9 @@ type WorldRepository interface {
 	// GetTotalZonesCountByUserId returns the total number of zones owned by a specific user.
 	GetTotalZonesCountByUserId(userId uuid.UUID) (int64, error)
 
+	// GetWorldIdsByUserId retrieves all world IDs associated with a specific user.
+	GetWorldIdsByUserId(userId uuid.UUID) ([]uuid.UUID, error)
+
 	// ClearDatabase is a utility function to clear the database, intended for testing purposes.
 	ClearDatabase() error
 }

--- a/internal/world-service/repositories/world/world.go
+++ b/internal/world-service/repositories/world/world.go
@@ -224,3 +224,9 @@ func (r *worldRepository) GetActiveWorldZones() ([]*models.WorldZone, error) {
 	}
 	return activeZones, nil
 }
+
+func (wr *worldRepository) GetWorldIdsByUserId(userId uuid.UUID) ([]uuid.UUID, error) {
+	var worldIds []uuid.UUID
+	err := wr.db.Conn.Model(&models.WorldData{}).Where("user_id = ?", userId).Pluck("id", &worldIds).Error
+	return worldIds, err
+}

--- a/internal/world-service/router/router.go
+++ b/internal/world-service/router/router.go
@@ -40,6 +40,8 @@ func SetupEndpointsForZonesService(worldGroup *gin.RouterGroup, db *config.DB, c
 	worldGroup.GET("/:id/zones/:zone_id", zonesController.GetWorldZoneData)
 	worldGroup.GET("/:id/zones/:zone_id/activate", zonesController.ActivateZone)
 	worldGroup.GET("/:id/zones/:zone_id/deactivate", zonesController.DeactivateZone)
+
+	worldGroup.GET("/internal/users/:user_id/stop-jobs", zonesController.StopAllJobsForUser)
 }
 
 func SetupEndpointsForServiceRegistry(orchestratorGroup *gin.RouterGroup, db *config.DB, conf *config.Config, nomadService server_registry_service.ServerRegistryService) error {

--- a/internal/world-service/services/zones/service.go
+++ b/internal/world-service/services/zones/service.go
@@ -24,4 +24,7 @@ type ZonesService interface {
 
 	// GetWorldZone returns one zone for a world.
 	GetWorldZone(worldID uuid.UUID, zoneID int) (*models.WorldZone, error)
+
+	// StopAllZonesForUser stops all active zones for a specific user.
+	StopAllZonesForUser(userID uuid.UUID) error
 }

--- a/internal/world-service/services/zones/zones.go
+++ b/internal/world-service/services/zones/zones.go
@@ -196,3 +196,27 @@ func (zs *zonesService) updateUsedSlots(userID uuid.UUID, numberOfSlots int, are
 
 	return nil
 }
+
+func (zs *zonesService) StopAllZonesForUser(userID uuid.UUID) error {
+	worldIDs, err := zs.worldRepository.GetWorldIdsByUserId(userID)
+	if err != nil {
+		return err
+	}
+
+	for _, worldID := range worldIDs {
+		zones, err := zs.worldRepository.GetWorldZones(worldID)
+		if err != nil {
+			return err
+		}
+
+		for _, zone := range zones {
+			if zone.IsActive {
+				if err := zs.DeactivateZone(worldID, zone.ID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -2105,7 +2105,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates the name, bio, and associated sprites map.",
+                "description": "Updates the name, bio, associated sprites map and skin/hair/eye color.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2810,6 +2810,48 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/world/internal/users/{user_id}/stop-jobs": {
+            "get": {
+                "description": "Internal endpoint to stop all active zones and jobs for a specific user. Triggered internally by the payment service on subscription cancellation.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "world-service",
+                    "internal"
+                ],
+                "summary": "Stop all jobs for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User UUID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Acknowledge jobs stopped",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/dtos.ErrorResponse"
                         }
@@ -3606,6 +3648,15 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "eye_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "hair_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "skin_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
                 "updated_at": {
                     "type": "string"
                 }
@@ -4044,6 +4095,15 @@ const docTemplate = `{
                 },
                 "character_name": {
                     "type": "string"
+                },
+                "eye_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "hair_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "skin_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
                 }
             }
         },
@@ -4339,6 +4399,20 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/dtos.WorldMetadata"
                     }
+                }
+            }
+        },
+        "models.CharacterColorHsv": {
+            "type": "object",
+            "properties": {
+                "h": {
+                    "type": "number"
+                },
+                "s": {
+                    "type": "number"
+                },
+                "v": {
+                    "type": "number"
                 }
             }
         }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2098,7 +2098,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates the name, bio, and associated sprites map.",
+                "description": "Updates the name, bio, associated sprites map and skin/hair/eye color.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2803,6 +2803,48 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/world/internal/users/{user_id}/stop-jobs": {
+            "get": {
+                "description": "Internal endpoint to stop all active zones and jobs for a specific user. Triggered internally by the payment service on subscription cancellation.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "world-service",
+                    "internal"
+                ],
+                "summary": "Stop all jobs for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User UUID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Acknowledge jobs stopped",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/dtos.ErrorResponse"
                         }
@@ -3599,6 +3641,15 @@
                 "created_at": {
                     "type": "string"
                 },
+                "eye_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "hair_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "skin_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
                 "updated_at": {
                     "type": "string"
                 }
@@ -4037,6 +4088,15 @@
                 },
                 "character_name": {
                     "type": "string"
+                },
+                "eye_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "hair_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
+                },
+                "skin_color": {
+                    "$ref": "#/definitions/models.CharacterColorHsv"
                 }
             }
         },
@@ -4332,6 +4392,20 @@
                     "items": {
                         "$ref": "#/definitions/dtos.WorldMetadata"
                     }
+                }
+            }
+        },
+        "models.CharacterColorHsv": {
+            "type": "object",
+            "properties": {
+                "h": {
+                    "type": "number"
+                },
+                "s": {
+                    "type": "number"
+                },
+                "v": {
+                    "type": "number"
                 }
             }
         }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -19,6 +19,12 @@ definitions:
         type: string
       created_at:
         type: string
+      eye_color:
+        $ref: '#/definitions/models.CharacterColorHsv'
+      hair_color:
+        $ref: '#/definitions/models.CharacterColorHsv'
+      skin_color:
+        $ref: '#/definitions/models.CharacterColorHsv'
       updated_at:
         type: string
     type: object
@@ -303,6 +309,12 @@ definitions:
         type: string
       character_name:
         type: string
+      eye_color:
+        $ref: '#/definitions/models.CharacterColorHsv'
+      hair_color:
+        $ref: '#/definitions/models.CharacterColorHsv'
+      skin_color:
+        $ref: '#/definitions/models.CharacterColorHsv'
     type: object
   dtos.PricingInfoResponse:
     properties:
@@ -494,6 +506,15 @@ definitions:
         items:
           $ref: '#/definitions/dtos.WorldMetadata'
         type: array
+    type: object
+  models.CharacterColorHsv:
+    properties:
+      h:
+        type: number
+      s:
+        type: number
+      v:
+        type: number
     type: object
 info:
   contact: {}
@@ -1863,7 +1884,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Updates the name, bio, and associated sprites map.
+      description: Updates the name, bio, associated sprites map and skin/hair/eye
+        color.
       parameters:
       - description: Patch Character DTO
         in: body
@@ -2663,6 +2685,35 @@ paths:
       summary: Deactivate zone
       tags:
       - world-service
+  /world/internal/users/{user_id}/stop-jobs:
+    get:
+      description: Internal endpoint to stop all active zones and jobs for a specific
+        user. Triggered internally by the payment service on subscription cancellation.
+      parameters:
+      - description: User UUID
+        in: path
+        name: user_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Acknowledge jobs stopped
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      summary: Stop all jobs for a user
+      tags:
+      - world-service
+      - internal
   /world/orchestrator/{id}/zones/{zone_id}/address:
     get:
       description: Returns resolved dynamically routed TCP/UDP IP and Port mappings


### PR DESCRIPTION
## Changes:

* Added `ZonesService.StopAllZonesForUser` and `ZonesController.StopAllJobsForUser` to deactivate all active zones across all worlds owned by a user
* Added `WorldRepository.GetWorldIdsByUserId` to fetch all world IDs for a given user
* Added internal endpoint `GET /world/internal/users/:user_id/stop-jobs` wired to the new controller method
* Added `zoneSubscriptionService.stopAllJobs` to call the internal stop-jobs endpoint and reset `UsedSlots` to zero when a subscription is cancelled or payment fails
* Added `invoice.payment_failed` webhook handler that logs the decline code, stops all jobs, and cancels the Stripe subscription
* Added `invoice.upcoming` webhook handler that restores the subscription status to active
* Added `checkout.session.expired` webhook handler with a log entry
* Fixed `subscription.updated` to only fetch the next invoice amount when the subscription is active, and added a warning log for `past_due` status
* Fixed missing `user_id` metadata errors in webhook handlers to return proper error messages instead of nil
* Fixed `CreateCheckoutSession` to return a descriptive error instead of a nil error when the user already has an active subscription

## Current webhooks events

**Payments**

1. `checkout.session.completed`
2. `checkout.session.async_payment_failed`
3. `checkout.session.expired`

**Subscription**

1. `customer.subscription.created`
2. `customer.subscription.updated`
3. `customer.subscription.deleted`
4. `invoice.payment_failed`
5. `invoice.upcoming`

Check webhooks for updated it to this events

## How to test it

To verify whether a payment failure is handled correctly, you would normally need to subscribe using a card, wait until the next 5th of the month, and let the payment be rejected to see if everything works as expected. However, in Stripe you can simulate the passage of time and also change the customer’s payment method.

<img width="1012" height="283" alt="image" src="https://github.com/user-attachments/assets/9d86a8ef-4de3-4f8e-b1bb-610be7fef24b" />

For example, here I simulated the passage of time and changed the customer’s payment method to the test card number `4000 0000 0000 0002`.

If you want to test this scenario, you should simulate the passage of time, search for your subscription, and you should see something like this:

<img width="1378" height="216" alt="image" src="https://github.com/user-attachments/assets/e54fc63f-7415-49b4-931e-1a823b4e58e0" />

To update the payment method, go here:

<img width="1016" height="76" alt="image" src="https://github.com/user-attachments/assets/3d9cddcb-42a7-41ca-bbb7-d5c40cecf5c5" />

And change it here:

<img width="850" height="204" alt="image" src="https://github.com/user-attachments/assets/98af6840-adaf-4f06-ac58-d21f98a995bb" />

After the first failed payment, the subscription is canceled and all zones for that user are stopped.