### PR TITLE
Bug-23: FTR-servers should notify online when loading finished

### DIFF
--- a/internal/common_handlers/context_getters.go
+++ b/internal/common_handlers/context_getters.go
@@ -33,6 +33,14 @@ func IsAdminSession(ctx *gin.Context) error {
 	return nil
 }
 
+// IsServerSession checks if the session has server privileges.
+func IsServerSession(ctx *gin.Context) error {
+	if err := IsSessionValid(ctx); err != nil && !ctx.GetBool("isServer") {
+		return &errors.NotServerSessionError{}
+	}
+	return nil
+}
+
 // GetUserIDFromSession checks if the session is valid and returns the userID from the session.
 func GetUserIDFromSession(ctx *gin.Context) (uuid.UUID, error) {
 	if err := IsSessionValid(ctx); err != nil {

--- a/internal/errors/session_error.go
+++ b/internal/errors/session_error.go
@@ -24,6 +24,13 @@ func (i *InvalidSessionError) Error() string {
 	return "session is invalid"
 }
 
+type NotServerSessionError struct {
+}
+
+func (n *NotServerSessionError) Error() string {
+	return "session does not have server privileges"
+}
+
 type NotAdminSessionError struct {
 }
 

--- a/internal/middleware/jwt_session.go
+++ b/internal/middleware/jwt_session.go
@@ -34,6 +34,7 @@ func JWTAuthMiddleware(jwtManager *session.JWTManager, fixedToken string) gin.Ha
 		// read-only endpoints that only check for a valid session to work.
 		if fixedToken != "" && tokenString == fixedToken {
 			c.Set("userID", "00000000-0000-0000-0000-000000000000")
+			c.Set("isServer", true)
 			return
 		}
 

--- a/internal/middleware/server_check.go
+++ b/internal/middleware/server_check.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"github.com/FeedTheRealm-org/core-service/internal/common_handlers"
+	"github.com/FeedTheRealm-org/core-service/internal/errors"
+	"github.com/gin-gonic/gin"
+)
+
+// ServerCheckMiddleware will check if the user is server before allowing swagger endpoints
+func ServerCheckMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := common_handlers.IsServerSession(c); err != nil {
+			c.Abort()
+			_ = c.Error(errors.NewForbiddenError(err.Error()))
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/world-service/controllers/server_registry/controller.go
+++ b/internal/world-service/controllers/server_registry/controller.go
@@ -15,4 +15,7 @@ type ServerRegistryController interface {
 
 	// UpdateServer is a webhook endpoint for reload server when image is updated.
 	UpdateServer(c *gin.Context)
+
+	// UpdateStatus is a webhook endpoint for updating server status.
+	UpdateStatus(c *gin.Context)
 }

--- a/internal/world-service/controllers/server_registry/server_registry.go
+++ b/internal/world-service/controllers/server_registry/server_registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/FeedTheRealm-org/core-service/internal/world-service/dtos"
 	"github.com/FeedTheRealm-org/core-service/internal/world-service/services/server_registry"
 	"github.com/FeedTheRealm-org/core-service/internal/world-service/services/world"
+	"github.com/FeedTheRealm-org/core-service/internal/world-service/services/zones"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -20,13 +21,15 @@ import (
 type serverRegistryController struct {
 	conf                  *config.Config
 	worldService          world.WorldService
+	zoneService           zones.ZonesService
 	nomadJobSenderService server_registry.ServerRegistryService
 }
 
-func NewServerRegistryController(conf *config.Config, worldService world.WorldService, nomadJobSenderService server_registry.ServerRegistryService) ServerRegistryController {
+func NewServerRegistryController(conf *config.Config, worldService world.WorldService, zoneService zones.ZonesService, nomadJobSenderService server_registry.ServerRegistryService) ServerRegistryController {
 	return &serverRegistryController{
 		conf:                  conf,
 		worldService:          worldService,
+		zoneService:           zoneService,
 		nomadJobSenderService: nomadJobSenderService,
 	}
 }
@@ -187,6 +190,51 @@ func (c *serverRegistryController) UpdateServer(ctx *gin.Context) {
 			_ = ctx.Error(errors.NewInternalServerError(err.Error()))
 			return
 		}
+	}
+
+	common_handlers.HandleBodilessResponse(ctx, http.StatusOK)
+}
+
+// UpdateStatus godoc
+// @Summary      Update zone status
+// @Description  Update the online status of a specific zone in a world.
+// @Tags         world-service
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        id path string true "World UUID"
+// @Param        zone_id path int true "World Zone Number"
+// @Param        request body dtos.UpdateStatusRequest true "Status Update Request"
+// @Success      200  {string}  string "OK"
+// @Failure      400  {object} dtos.ErrorResponse
+// @Failure      500  {object} dtos.ErrorResponse
+// @Router       /world/orchestrator/{id}/zones/{zone_id}/status [post]
+func (c *serverRegistryController) UpdateStatus(ctx *gin.Context) {
+	worldIdStr := ctx.Param("id")
+	zoneIdStr := ctx.Param("zone_id")
+
+	worldId, err := uuid.Parse(worldIdStr)
+	if err != nil {
+		_ = ctx.Error(errors.NewBadRequestError("invalid world ID: " + worldIdStr))
+		return
+	}
+
+	zoneId, err := strconv.Atoi(zoneIdStr)
+	if err != nil {
+		_ = ctx.Error(errors.NewBadRequestError("invalid zone ID: " + zoneIdStr))
+		return
+	}
+
+	var req dtos.UpdateStatusRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		_ = ctx.Error(errors.NewBadRequestError("invalid request body: " + err.Error()))
+		return
+	}
+
+	err = c.zoneService.UpdateZoneStatus(worldId, zoneId, req.IsOnline)
+	if err != nil {
+		_ = ctx.Error(errors.NewInternalServerError(err.Error()))
+		return
 	}
 
 	common_handlers.HandleBodilessResponse(ctx, http.StatusOK)

--- a/internal/world-service/dtos/requests_dto.go
+++ b/internal/world-service/dtos/requests_dto.go
@@ -15,3 +15,7 @@ type UpdateCreateableDataRequest struct {
 type PublishZoneRequest struct {
 	Data any `json:"data"`
 }
+
+type UpdateStatusRequest struct {
+	IsOnline bool `json:"is_online"`
+}

--- a/internal/world-service/router/router.go
+++ b/internal/world-service/router/router.go
@@ -52,12 +52,14 @@ func SetupEndpointsForServiceRegistry(orchestratorGroup *gin.RouterGroup, db *co
 
 	worldRepo := world_repo.NewWorldRepository(conf, db)
 	worldService := world_service.NewWorldService(conf, worldRepo, nomadService)
-	serverRegistryController := server_registry_controller.NewServerRegistryController(conf, worldService, nomadService)
+	zoneService := zones_service.NewZonesService(conf, worldRepo, nomadService)
+	serverRegistryController := server_registry_controller.NewServerRegistryController(conf, worldService, zoneService, nomadService)
 
 	orchestratorGroup.GET("/:id/zones/:zone_id/start-job", middleware.AdminCheckMiddleware(), serverRegistryController.StartNewJob)
 	orchestratorGroup.GET("/:id/zones/:zone_id/stop-job", middleware.AdminCheckMiddleware(), serverRegistryController.StopJob)
 	orchestratorGroup.GET("/:id/zones/:zone_id/address", serverRegistryController.GetServerAddress)
 	orchestratorGroup.POST("/webhook/servers/update", middleware.GithubOIDCCheck(ghv), serverRegistryController.UpdateServer)
+	orchestratorGroup.PUT("/:id/zones/:zone_id/status", middleware.ServerCheckMiddleware(), serverRegistryController.UpdateStatus)
 
 	return nil
 }

--- a/internal/world-service/services/zones/service.go
+++ b/internal/world-service/services/zones/service.go
@@ -25,6 +25,9 @@ type ZonesService interface {
 	// GetWorldZone returns one zone for a world.
 	GetWorldZone(worldID uuid.UUID, zoneID int) (*models.WorldZone, error)
 
+	// UpdateZoneStatus updates the status of a zone.
+	UpdateZoneStatus(worldID uuid.UUID, zoneID int, isOnline bool) error
+
 	// StopAllZonesForUser stops all active zones for a specific user.
 	StopAllZonesForUser(userID uuid.UUID) error
 }

--- a/internal/world-service/services/zones/zones.go
+++ b/internal/world-service/services/zones/zones.go
@@ -197,6 +197,10 @@ func (zs *zonesService) updateUsedSlots(userID uuid.UUID, numberOfSlots int, are
 	return nil
 }
 
+func (zs *zonesService) UpdateZoneStatus(worldID uuid.UUID, zoneID int, isOnline bool) error {
+	return zs.worldRepository.SetWorldZoneOnlineState(worldID, zoneID, isOnline)
+}
+
 func (zs *zonesService) StopAllZonesForUser(userID uuid.UUID) error {
 	worldIDs, err := zs.worldRepository.GetWorldIdsByUserId(userID)
 	if err != nil {

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3009,6 +3009,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/world/orchestrator/{id}/zones/{zone_id}/status": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the online status of a specific zone in a world.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "world-service"
+                ],
+                "summary": "Update zone status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "World UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "World Zone Number",
+                        "name": "zone_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Status Update Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UpdateStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/world/orchestrator/{id}/zones/{zone_id}/stop-job": {
             "get": {
                 "security": [
@@ -4207,6 +4272,14 @@ const docTemplate = `{
                 },
                 "price": {
                     "type": "number"
+                }
+            }
+        },
+        "dtos.UpdateStatusRequest": {
+            "type": "object",
+            "properties": {
+                "is_online": {
+                    "type": "boolean"
                 }
             }
         },

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3002,6 +3002,71 @@
                 }
             }
         },
+        "/world/orchestrator/{id}/zones/{zone_id}/status": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the online status of a specific zone in a world.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "world-service"
+                ],
+                "summary": "Update zone status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "World UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "World Zone Number",
+                        "name": "zone_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Status Update Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UpdateStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/world/orchestrator/{id}/zones/{zone_id}/stop-job": {
             "get": {
                 "security": [
@@ -4200,6 +4265,14 @@
                 },
                 "price": {
                     "type": "number"
+                }
+            }
+        },
+        "dtos.UpdateStatusRequest": {
+            "type": "object",
+            "properties": {
+                "is_online": {
+                    "type": "boolean"
                 }
             }
         },

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -382,6 +382,11 @@ definitions:
       price:
         type: number
     type: object
+  dtos.UpdateStatusRequest:
+    properties:
+      is_online:
+        type: boolean
+    type: object
   dtos.UpdateSubscriptionRequest:
     properties:
       slots:
@@ -2787,6 +2792,48 @@ paths:
       security:
       - BearerAuth: []
       summary: Start Nomad allocation Job
+      tags:
+      - world-service
+  /world/orchestrator/{id}/zones/{zone_id}/status:
+    post:
+      consumes:
+      - application/json
+      description: Update the online status of a specific zone in a world.
+      parameters:
+      - description: World UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: World Zone Number
+        in: path
+        name: zone_id
+        required: true
+        type: integer
+      - description: Status Update Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.UpdateStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update zone status
       tags:
       - world-service
   /world/orchestrator/{id}/zones/{zone_id}/stop-job:


### PR DESCRIPTION
## Changes:

* Added `PUT /world/orchestrator/:id/zones/:zone_id/status` endpoint to update a zone's `is_online` state, gated by the new `ServerCheckMiddleware`
* Added `ServerCheckMiddleware` that checks the `isServer` context flag set by the fixed-token path in `JWTAuthMiddleware`
* Added `IsServerSession` context helper and `NotServerSessionError` error type
* Added `ZonesService.UpdateZoneStatus` and wired it through to `SetWorldZoneOnlineState` in the repository
* Added `UpdateStatusRequest` DTO with `is_online` field
* Updated `NewServerRegistryController` to accept `ZonesService` for use in the new status endpoint
* Updated Swagger docs with the new endpoint and DTO