### PR TITLE
US-101: Password Reset

### DIFF
--- a/docs/ftr-core-service-bruno/authentication-service/Forgot password.yml
+++ b/docs/ftr-core-service-bruno/authentication-service/Forgot password.yml
@@ -1,0 +1,69 @@
+info:
+  name: Forgot password
+  type: http
+  seq: 9
+  tags:
+    - authentication-service
+
+http:
+  method: POST
+  url: "{{baseUrl}}/auth/password/forgot"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "santisevitz@hotmail.com"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+
+examples:
+  - name: 200 Response
+    description: OK - Always returned regardless of whether the account exists
+    request:
+      url: "{{baseUrl}}/auth/password/forgot"
+      method: POST
+      body:
+        type: json
+        data: |-
+          {
+            "email": "player@example.com"
+          }
+    response:
+      status: 200
+      statusText: OK
+      body:
+        type: json
+        data: |-
+          {
+            "data": {
+              "success": true
+            }
+          }
+  - name: 400 Response
+    description: Bad Request
+    request:
+      url: "{{baseUrl}}/auth/password/forgot"
+      method: POST
+    response:
+      status: 400
+      statusText: Bad Request
+      body:
+        type: text
+        data: ""
+  - name: 500 Response
+    description: Internal Server Error
+    request:
+      url: "{{baseUrl}}/auth/password/forgot"
+      method: POST
+    response:
+      status: 500
+      statusText: Internal Server Error
+      body:
+        type: text
+        data: ""

--- a/docs/ftr-core-service-bruno/authentication-service/Forgot password.yml
+++ b/docs/ftr-core-service-bruno/authentication-service/Forgot password.yml
@@ -12,7 +12,7 @@ http:
     type: json
     data: |-
       {
-        "email": "santisevitz@hotmail.com"
+        "email": "player@example.com"
       }
   auth: inherit
 

--- a/docs/ftr-core-service-bruno/authentication-service/Reset password.yml
+++ b/docs/ftr-core-service-bruno/authentication-service/Reset password.yml
@@ -1,0 +1,96 @@
+info:
+  name: Reset password
+  type: http
+  seq: 11
+  tags:
+    - authentication-service
+
+http:
+  method: POST
+  url: "{{baseUrl}}/auth/password/reset"
+  body:
+    type: json
+    data: |-
+      {
+        "reset_token": "{{resetToken}}",
+        "new_password": "MyNewPassword123!"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+
+examples:
+  - name: 200 Response
+    description: OK - Password updated, all sessions revoked
+    request:
+      url: "{{baseUrl}}/auth/password/reset"
+      method: POST
+      body:
+        type: json
+        data: |-
+          {
+            "reset_token": "{{resetToken}}",
+            "new_password": "MyNewPassword123!"
+          }
+    response:
+      status: 200
+      statusText: OK
+      body:
+        type: json
+        data: |-
+          {
+            "data": {
+              "success": true
+            }
+          }
+  - name: 400 Response
+    description: Bad Request - Invalid password format
+    request:
+      url: "{{baseUrl}}/auth/password/reset"
+      method: POST
+      body:
+        type: json
+        data: |-
+          {
+            "reset_token": "{{resetToken}}",
+            "new_password": "weak"
+          }
+    response:
+      status: 400
+      statusText: Bad Request
+      body:
+        type: text
+        data: ""
+  - name: 401 Response
+    description: Unauthorized - Invalid or expired reset token
+    request:
+      url: "{{baseUrl}}/auth/password/reset"
+      method: POST
+      body:
+        type: json
+        data: |-
+          {
+            "reset_token": "invalidtoken",
+            "new_password": "MyNewPassword123!"
+          }
+    response:
+      status: 401
+      statusText: Unauthorized
+      body:
+        type: text
+        data: ""
+  - name: 500 Response
+    description: Internal Server Error
+    request:
+      url: "{{baseUrl}}/auth/password/reset"
+      method: POST
+    response:
+      status: 500
+      statusText: Internal Server Error
+      body:
+        type: text
+        data: ""

--- a/docs/ftr-core-service-bruno/authentication-service/Verify password reset code.yml
+++ b/docs/ftr-core-service-bruno/authentication-service/Verify password reset code.yml
@@ -1,0 +1,97 @@
+info:
+  name: Verify password reset code
+  type: http
+  seq: 10
+  tags:
+    - authentication-service
+
+http:
+  method: POST
+  url: "{{baseUrl}}/auth/password/verify-code"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "player@example.com",
+        "code": "482193"
+      }
+  auth: inherit
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        response = res.getBody()
+        resetToken = response.data["reset_token"]
+        bru.setEnvVar("resetToken", resetToken)
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+
+examples:
+  - name: 200 Response
+    description: OK - OTP verified, reset token issued
+    request:
+      url: "{{baseUrl}}/auth/password/verify-code"
+      method: POST
+      body:
+        type: json
+        data: |-
+          {
+            "email": "player@example.com",
+            "code": "482193"
+          }
+    response:
+      status: 200
+      statusText: OK
+      body:
+        type: json
+        data: |-
+          {
+            "data": {
+              "reset_token": "a3f8c2..."
+            }
+          }
+  - name: 400 Response
+    description: Bad Request
+    request:
+      url: "{{baseUrl}}/auth/password/verify-code"
+      method: POST
+    response:
+      status: 400
+      statusText: Bad Request
+      body:
+        type: text
+        data: ""
+  - name: 401 Response
+    description: Unauthorized - Invalid, expired, or max attempts reached
+    request:
+      url: "{{baseUrl}}/auth/password/verify-code"
+      method: POST
+      body:
+        type: json
+        data: |-
+          {
+            "email": "player@example.com",
+            "code": "000000"
+          }
+    response:
+      status: 401
+      statusText: Unauthorized
+      body:
+        type: text
+        data: ""
+  - name: 500 Response
+    description: Internal Server Error
+    request:
+      url: "{{baseUrl}}/auth/password/verify-code"
+      method: POST
+    response:
+      status: 500
+      statusText: Internal Server Error
+      body:
+        type: text
+        data: ""

--- a/internal/authentication-service/controllers/account.go
+++ b/internal/authentication-service/controllers/account.go
@@ -355,6 +355,161 @@ func (ec *accountController) RefreshVerification(c *gin.Context) {
 	common_handlers.HandleSuccessResponse(c, http.StatusOK, res)
 }
 
+// @Summary      Forgot password
+// @Description  Initiates a password reset flow by sending an OTP to the user's email. Always returns success to prevent account enumeration.
+// @Tags         authentication-service
+// @Accept       json
+// @Produce      json
+// @Param        request body dtos.ForgotPasswordRequestDTO true "Email address"
+// @Success      200  {object}  dtos.ForgotPasswordResponseDTO
+// @Failure      400  {object} dtos.ErrorResponse
+// @Failure      500  {object} dtos.ErrorResponse
+// @Router       /auth/password/forgot [post]
+func (ec *accountController) ForgotPassword(c *gin.Context) {
+	req := dtos.ForgotPasswordRequestDTO{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		logger.Logger.Errorf("ForgotPassword: failed to bind JSON: %v", err)
+		_ = c.Error(errors.NewBadRequestError("The request body is not valid JSON."))
+		return
+	}
+
+	if req.Email == "" {
+		logger.Logger.Info("ForgotPassword: missing email")
+		_ = c.Error(errors.NewBadRequestError("You must provide an email address."))
+		return
+	}
+
+	otpCode, err := ec.accountService.ForgotPassword(req.Email)
+	if err != nil {
+		logger.Logger.Errorf("ForgotPassword: service error for email=%s: %v", req.Email, err)
+		// Return success anyway — never reveal internal errors to prevent enumeration.
+		common_handlers.HandleSuccessResponse(c, http.StatusOK, &dtos.ForgotPasswordResponseDTO{Success: true})
+		return
+	}
+
+	if otpCode != "" && ec.conf.Server.Environment != config.Testing {
+		if err := ec.emailService.SendPasswordResetEmail(req.Email, otpCode); err != nil {
+			logger.Logger.Errorf("ForgotPassword: failed to send password reset email to email=%s: %v", req.Email, err)
+		}
+	}
+
+	logger.Logger.Infof("ForgotPassword: password reset flow initiated for email=%s", req.Email)
+	common_handlers.HandleSuccessResponse(c, http.StatusOK, &dtos.ForgotPasswordResponseDTO{Success: true})
+}
+
+// @Summary      Verify password reset code
+// @Description  Validates the OTP sent to the user's email and returns a short-lived reset token on success.
+// @Tags         authentication-service
+// @Accept       json
+// @Produce      json
+// @Param        request body dtos.VerifyPasswordCodeRequestDTO true "Email and OTP code"
+// @Success      200  {object}  dtos.VerifyPasswordCodeResponseDTO
+// @Failure      400  {object} dtos.ErrorResponse
+// @Failure      401  {object} dtos.ErrorResponse
+// @Failure      500  {object} dtos.ErrorResponse
+// @Router       /auth/password/verify-code [post]
+func (ec *accountController) VerifyPasswordCode(c *gin.Context) {
+	req := dtos.VerifyPasswordCodeRequestDTO{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		logger.Logger.Errorf("VerifyPasswordCode: failed to bind JSON: %v", err)
+		_ = c.Error(errors.NewBadRequestError("The request body is not valid JSON."))
+		return
+	}
+
+	if req.Email == "" {
+		logger.Logger.Info("VerifyPasswordCode: missing email")
+		_ = c.Error(errors.NewBadRequestError("You must provide an email address."))
+		return
+	}
+
+	if req.Code == "" {
+		logger.Logger.Info("VerifyPasswordCode: missing code")
+		_ = c.Error(errors.NewBadRequestError("You must provide a verification code."))
+		return
+	}
+
+	logger.Logger.Infof("VerifyPasswordCode: received request for email=%s", req.Email)
+
+	resetToken, err := ec.accountService.VerifyPasswordResetCode(req.Email, req.Code)
+	if err != nil {
+		switch err.(type) {
+		case *services.PasswordResetNotFoundError:
+			logger.Logger.Infof("VerifyPasswordCode: no active reset found for email=%s", req.Email)
+		case *services.PasswordResetExpiredError:
+			logger.Logger.Infof("VerifyPasswordCode: OTP expired for email=%s", req.Email)
+		case *services.PasswordResetMaxAttemptsError:
+			logger.Logger.Warnf("VerifyPasswordCode: max attempts reached for email=%s", req.Email)
+		case *services.InvalidPasswordResetCodeError:
+			logger.Logger.Infof("VerifyPasswordCode: invalid code for email=%s", req.Email)
+		default:
+			logger.Logger.Errorf("VerifyPasswordCode: service error for email=%s: %v", req.Email, err)
+			_ = c.Error(errors.NewInternalServerError("An unexpected error occurred."))
+			return
+		}
+		_ = c.Error(errors.NewUnauthorizedError("The verification code is incorrect or has expired."))
+		return
+	}
+
+	logger.Logger.Infof("VerifyPasswordCode: OTP verified, reset token issued for email=%s", req.Email)
+	common_handlers.HandleSuccessResponse(c, http.StatusOK, &dtos.VerifyPasswordCodeResponseDTO{ResetToken: resetToken})
+}
+
+// @Summary      Reset password
+// @Description  Validates the reset token and updates the user's password, revoking all active sessions.
+// @Tags         authentication-service
+// @Accept       json
+// @Produce      json
+// @Param        request body dtos.ResetPasswordRequestDTO true "Reset token and new password"
+// @Success      200  {object}  dtos.ResetPasswordResponseDTO
+// @Failure      400  {object} dtos.ErrorResponse
+// @Failure      401  {object} dtos.ErrorResponse
+// @Failure      500  {object} dtos.ErrorResponse
+// @Router       /auth/password/reset [post]
+func (ec *accountController) ResetPassword(c *gin.Context) {
+	req := dtos.ResetPasswordRequestDTO{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		logger.Logger.Errorf("ResetPassword: failed to bind JSON: %v", err)
+		_ = c.Error(errors.NewBadRequestError("The request body is not valid JSON."))
+		return
+	}
+
+	if req.ResetToken == "" {
+		logger.Logger.Info("ResetPassword: missing reset token")
+		_ = c.Error(errors.NewBadRequestError("You must provide a reset token."))
+		return
+	}
+
+	if req.NewPassword == "" {
+		logger.Logger.Info("ResetPassword: missing new password")
+		_ = c.Error(errors.NewBadRequestError("You must provide a new password."))
+		return
+	}
+
+	logger.Logger.Info("ResetPassword: received password reset request")
+
+	err := ec.accountService.ResetPassword(req.ResetToken, req.NewPassword)
+	if err != nil {
+		switch e := err.(type) {
+		case *services.PasswordResetNotFoundError:
+			logger.Logger.Infof("ResetPassword: reset token not found")
+			_ = c.Error(errors.NewUnauthorizedError("The reset token is invalid or has already been used."))
+		case *services.PasswordResetTokenExpiredError:
+			logger.Logger.Infof("ResetPassword: reset token expired")
+			_ = c.Error(errors.NewUnauthorizedError("The reset token has expired. Please start over."))
+		case *services.AccountInvalidFormat:
+			logger.Logger.Infof("ResetPassword: invalid password format: %s", e.Msg)
+			_ = c.Error(errors.NewBadRequestError(e.Msg))
+		default:
+			logger.Logger.Errorf("ResetPassword: service error: %v", err)
+			_ = c.Error(errors.NewInternalServerError("An unexpected error occurred."))
+		}
+		return
+	}
+
+	logger.Logger.Info("ResetPassword: password reset successful")
+	common_handlers.HandleSuccessResponse(c, http.StatusOK, &dtos.ResetPasswordResponseDTO{Success: true})
+}
+
 // @Summary      Refresh access token
 // @Description  Validates the provided refresh token and issues a new access token and refresh token pair.
 // @Tags         authentication-service

--- a/internal/authentication-service/controllers/interface_account.go
+++ b/internal/authentication-service/controllers/interface_account.go
@@ -9,4 +9,7 @@ type AccountController interface {
 	VerifyAccount(c *gin.Context)
 	RefreshVerification(c *gin.Context)
 	RefreshToken(c *gin.Context)
+	ForgotPassword(c *gin.Context)
+	VerifyPasswordCode(c *gin.Context)
+	ResetPassword(c *gin.Context)
 }

--- a/internal/authentication-service/dtos/auth_services_dtos.go
+++ b/internal/authentication-service/dtos/auth_services_dtos.go
@@ -56,3 +56,29 @@ type RefreshTokenResponseDTO struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 }
+
+type ForgotPasswordRequestDTO struct {
+	Email string `json:"email"`
+}
+
+type ForgotPasswordResponseDTO struct {
+	Success bool `json:"success"`
+}
+
+type VerifyPasswordCodeRequestDTO struct {
+	Email string `json:"email"`
+	Code  string `json:"code"`
+}
+
+type VerifyPasswordCodeResponseDTO struct {
+	ResetToken string `json:"reset_token"`
+}
+
+type ResetPasswordRequestDTO struct {
+	ResetToken  string `json:"reset_token"`
+	NewPassword string `json:"new_password"`
+}
+
+type ResetPasswordResponseDTO struct {
+	Success bool `json:"success"`
+}

--- a/internal/authentication-service/models/password_reset.go
+++ b/internal/authentication-service/models/password_reset.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PasswordReset struct {
+	Id                  uuid.UUID  `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+	UserId              uuid.UUID  `gorm:"column:user_id;not null;index"`
+	OTPHash             string     `gorm:"column:otp_hash;not null"`
+	ResetTokenHash      string     `gorm:"column:reset_token_hash"`
+	Attempts            int        `gorm:"not null;default:0"`
+	OTPExpiresAt        time.Time  `gorm:"column:otp_expires_at;not null"`
+	ResetTokenExpiresAt *time.Time `gorm:"column:reset_token_expires_at"`
+	OTPVerified         bool       `gorm:"column:otp_verified;not null;default:false"`
+	Used                bool       `gorm:"not null;default:false"`
+	CreatedAt           time.Time  `gorm:"autoCreateTime"`
+
+	User User `gorm:"foreignKey:UserId"`
+}

--- a/internal/authentication-service/repositories/account.go
+++ b/internal/authentication-service/repositories/account.go
@@ -187,3 +187,87 @@ func (ar *accountRepository) UpdateRefreshTokenUpdatedAt(id uuid.UUID, updatedAt
 	}
 	return nil
 }
+
+func (ar *accountRepository) CreatePasswordReset(userID uuid.UUID, otpHash string, expiresAt time.Time) (*models.PasswordReset, error) {
+	reset := &models.PasswordReset{
+		UserId:       userID,
+		OTPHash:      otpHash,
+		OTPExpiresAt: expiresAt,
+		Attempts:     0,
+		OTPVerified:  false,
+		Used:         false,
+	}
+	if err := ar.db.Conn.Create(reset).Error; err != nil {
+		return nil, &DatabaseError{message: err.Error()}
+	}
+	return reset, nil
+}
+
+func (ar *accountRepository) GetActivePasswordResetByUserID(userID uuid.UUID) (*models.PasswordReset, error) {
+	var reset models.PasswordReset
+	err := ar.db.Conn.
+		Where("user_id = ? AND used = false", userID).
+		Order("created_at DESC").
+		First(&reset).Error
+	if err != nil {
+		if errors.IsRecordNotFound(err) {
+			return nil, &AccountNotFoundError{}
+		}
+		return nil, &DatabaseError{message: err.Error()}
+	}
+	return &reset, nil
+}
+
+func (ar *accountRepository) IncrementPasswordResetAttempts(resetID uuid.UUID) error {
+	if err := ar.db.Conn.Model(&models.PasswordReset{}).
+		Where("id = ?", resetID).
+		UpdateColumn("attempts", gorm.Expr("attempts + 1")).Error; err != nil {
+		return &DatabaseError{message: err.Error()}
+	}
+	return nil
+}
+
+func (ar *accountRepository) MarkPasswordResetOTPVerified(resetID uuid.UUID, resetTokenHash string, resetTokenExpiresAt time.Time) error {
+	if err := ar.db.Conn.Model(&models.PasswordReset{}).
+		Where("id = ?", resetID).
+		Updates(map[string]interface{}{
+			"otp_verified":           true,
+			"reset_token_hash":       resetTokenHash,
+			"reset_token_expires_at": resetTokenExpiresAt,
+		}).Error; err != nil {
+		return &DatabaseError{message: err.Error()}
+	}
+	return nil
+}
+
+func (ar *accountRepository) GetPasswordResetByTokenHash(tokenHash string) (*models.PasswordReset, error) {
+	var reset models.PasswordReset
+	err := ar.db.Conn.
+		Where("reset_token_hash = ? AND used = false AND otp_verified = true", tokenHash).
+		First(&reset).Error
+	if err != nil {
+		if errors.IsRecordNotFound(err) {
+			return nil, &AccountNotFoundError{}
+		}
+		return nil, &DatabaseError{message: err.Error()}
+	}
+	return &reset, nil
+}
+
+func (ar *accountRepository) InvalidateAllPasswordResets(userID uuid.UUID) error {
+	if err := ar.db.Conn.Model(&models.PasswordReset{}).
+		Where("user_id = ? AND used = false", userID).
+		Update("used", true).Error; err != nil {
+		return &DatabaseError{message: err.Error()}
+	}
+	return nil
+}
+
+func (ar *accountRepository) UpdatePassword(userID uuid.UUID, hashedPassword string) error {
+	if err := ar.db.Conn.Model(&models.User{}).
+		Where("id = ?", userID).
+		Update("password", hashedPassword).Error; err != nil {
+		return &DatabaseError{message: err.Error()}
+	}
+	return nil
+}

--- a/internal/authentication-service/repositories/interface_account.go
+++ b/internal/authentication-service/repositories/interface_account.go
@@ -14,4 +14,13 @@ type AccountRepository interface {
 	VerifyAccount(user *models.User, code string, currentTime time.Time) error
 	RefreshVerificationCode(user *models.User, verificationCode string, expiresAt time.Time) error
 	UpdateRefreshTokenUpdatedAt(id uuid.UUID, updatedAt time.Time) error
+
+	// Password reset
+	CreatePasswordReset(userID uuid.UUID, otpHash string, expiresAt time.Time) (*models.PasswordReset, error)
+	GetActivePasswordResetByUserID(userID uuid.UUID) (*models.PasswordReset, error)
+	IncrementPasswordResetAttempts(resetID uuid.UUID) error
+	MarkPasswordResetOTPVerified(resetID uuid.UUID, resetTokenHash string, resetTokenExpiresAt time.Time) error
+	GetPasswordResetByTokenHash(tokenHash string) (*models.PasswordReset, error)
+	InvalidateAllPasswordResets(userID uuid.UUID) error
+	UpdatePassword(userID uuid.UUID, hashedPassword string) error
 }

--- a/internal/authentication-service/router/router.go
+++ b/internal/authentication-service/router/router.go
@@ -30,6 +30,13 @@ func SetupAuthenticationServiceRouter(r *gin.Engine, conf *config.Config, db *co
 	g.POST("/refresh-token", accountController.RefreshToken)
 	g.GET("/check-session", accountController.CheckSessionExpiration)
 
+	password := g.Group("/password")
+	{
+		password.POST("/forgot", accountController.ForgotPassword)
+		password.POST("/verify-code", accountController.VerifyPasswordCode)
+		password.POST("/reset", accountController.ResetPassword)
+	}
+
 	g.GET("", adminController.AdminLoginPageHandler)
 	g.POST("", adminController.AdminLoginHandler)
 

--- a/internal/authentication-service/services/account.go
+++ b/internal/authentication-service/services/account.go
@@ -1,8 +1,14 @@
 package services
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	mathrand "math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/FeedTheRealm-org/core-service/config"
@@ -16,10 +22,58 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	passwordResetOTPExpiry        = 10 * time.Minute
+	passwordResetTokenExpiry      = 15 * time.Minute
+	passwordResetMaxAttempts      = 5
+	forgotPasswordRateLimitReqs   = 3
+	forgotPasswordRateLimitWindow = 15 * time.Minute
+)
+
+type rateLimiter struct {
+	mu       sync.Mutex
+	requests map[string][]time.Time
+	maxReqs  int
+	window   time.Duration
+}
+
+func newRateLimiter(maxReqs int, window time.Duration) *rateLimiter {
+	return &rateLimiter{
+		requests: make(map[string][]time.Time),
+		maxReqs:  maxReqs,
+		window:   window,
+	}
+}
+
+func (r *rateLimiter) Allow(key string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-r.window)
+
+	existing := r.requests[key]
+	filtered := existing[:0]
+	for _, t := range existing {
+		if t.After(cutoff) {
+			filtered = append(filtered, t)
+		}
+	}
+
+	if len(filtered) >= r.maxReqs {
+		r.requests[key] = filtered
+		return false
+	}
+
+	r.requests[key] = append(filtered, now)
+	return true
+}
+
 type accountService struct {
-	conf *config.Config
-	repo repositories.AccountRepository
-	jwt  *session.JWTManager
+	conf              *config.Config
+	repo              repositories.AccountRepository
+	jwt               *session.JWTManager
+	forgotRateLimiter *rateLimiter
 }
 
 type AccountNotFoundError struct{}
@@ -90,6 +144,42 @@ func (e *AccountInvalidFormat) Error() string {
 	return "Account format is invalid"
 }
 
+type PasswordResetNotFoundError struct{}
+
+func (e *PasswordResetNotFoundError) Error() string {
+	return "Password reset request not found or expired"
+}
+
+type PasswordResetExpiredError struct{}
+
+func (e *PasswordResetExpiredError) Error() string {
+	return "Password reset code has expired"
+}
+
+type PasswordResetMaxAttemptsError struct{}
+
+func (e *PasswordResetMaxAttemptsError) Error() string {
+	return "Too many incorrect attempts"
+}
+
+type InvalidPasswordResetCodeError struct{}
+
+func (e *InvalidPasswordResetCodeError) Error() string {
+	return "Invalid password reset code"
+}
+
+type PasswordResetTokenExpiredError struct{}
+
+func (e *PasswordResetTokenExpiredError) Error() string {
+	return "Password reset token has expired"
+}
+
+type PasswordResetTokenAlreadyUsedError struct{}
+
+func (e *PasswordResetTokenAlreadyUsedError) Error() string {
+	return "Password reset token has already been used"
+}
+
 func (s *accountService) seedAdminAccount(conf *config.Config) {
 	adminEmail := conf.Server.AdminEmail
 	adminPassword := conf.Server.AdminPassword
@@ -119,9 +209,10 @@ func (s *accountService) seedAdminAccount(conf *config.Config) {
 
 func NewAccountService(conf *config.Config, repo repositories.AccountRepository, jwtManager *session.JWTManager) AccountService {
 	newAccountService := &accountService{
-		conf: conf,
-		repo: repo,
-		jwt:  jwtManager,
+		conf:              conf,
+		repo:              repo,
+		jwt:               jwtManager,
+		forgotRateLimiter: newRateLimiter(forgotPasswordRateLimitReqs, forgotPasswordRateLimitWindow),
 	}
 
 	newAccountService.seedAdminAccount(conf)
@@ -195,7 +286,7 @@ func (s *accountService) CreateAccount(email string, password string, isAdmin bo
 		return nil, "", &AccountFailedToCreateError{}
 	}
 
-	functionGenerator := rand.Int
+	functionGenerator := mathrand.Int
 	if s.conf.Server.Environment == config.Testing {
 		functionGenerator = code_generator.StaticGenerateCode
 	}
@@ -349,7 +440,7 @@ func (s *accountService) RefreshVerificationCode(email string) (string, error) {
 		return "", &AccountAlreadyVerifiedError{}
 	}
 
-	functionGenerator := rand.Int
+	functionGenerator := mathrand.Int
 	if s.conf.Server.Environment == config.Testing {
 		functionGenerator = code_generator.StaticGenerateCode
 	}
@@ -391,4 +482,176 @@ func (s *accountService) RefreshToken(email string) (string, string, error) {
 	}
 
 	return accessToken, refreshToken, nil
+}
+
+// generateOTP returns a cryptographically secure 6-digit numeric OTP and its bcrypt hash.
+func generateOTP() (plaintext string, hash string, err error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(900000))
+	if err != nil {
+		return "", "", err
+	}
+	plaintext = fmt.Sprintf("%06d", n.Int64()+100000)
+	hash, err = hashing.HashPassword(plaintext)
+	if err != nil {
+		return "", "", err
+	}
+	return plaintext, hash, nil
+}
+
+// generateResetToken returns a cryptographically secure hex token and its SHA-256 hex hash for DB lookup.
+func generateResetToken() (plaintext string, tokenHash string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", err
+	}
+	plaintext = hex.EncodeToString(b)
+	sum := sha256.Sum256([]byte(plaintext))
+	tokenHash = hex.EncodeToString(sum[:])
+	return plaintext, tokenHash, nil
+}
+
+// ForgotPassword generates a password reset OTP for the given email.
+// It always returns success to the caller to avoid leaking account existence.
+// Returns the plaintext OTP (for email delivery) and nil error when a reset was created.
+// Returns ("", nil) when the email is unknown or rate-limited — caller must treat all cases as success.
+func (s *accountService) ForgotPassword(email string) (string, error) {
+	email = strings.ToLower(email)
+
+	if !s.forgotRateLimiter.Allow(email) {
+		logger.Logger.Warnf("ForgotPassword: rate limit exceeded for email=%s", email)
+		return "", nil
+	}
+
+	user, err := s.repo.GetAccountByEmail(email)
+	if err != nil {
+		logger.Logger.Infof("ForgotPassword: account not found for email=%s, silently skipping", email)
+		return "", nil
+	}
+
+	otpPlain, otpHash, err := generateOTP()
+	if err != nil {
+		logger.Logger.Errorf("ForgotPassword: failed to generate OTP for user=%s: %v", user.Id, err)
+		return "", &AccountFailedToCreateError{}
+	}
+
+	// Invalidate any pending resets before creating a new one.
+	if err := s.repo.InvalidateAllPasswordResets(user.Id); err != nil {
+		logger.Logger.Warnf("ForgotPassword: failed to invalidate old resets for user=%s: %v", user.Id, err)
+	}
+
+	expiresAt := time.Now().Add(passwordResetOTPExpiry)
+	if _, err := s.repo.CreatePasswordReset(user.Id, otpHash, expiresAt); err != nil {
+		logger.Logger.Errorf("ForgotPassword: failed to create password reset record for user=%s: %v", user.Id, err)
+		return "", &AccountFailedToCreateError{}
+	}
+
+	logger.Logger.Infof("ForgotPassword: password reset OTP created for user=%s", user.Id)
+	return otpPlain, nil
+}
+
+// VerifyPasswordResetCode validates the OTP and, on success, issues a single-use reset token.
+func (s *accountService) VerifyPasswordResetCode(email string, code string) (string, error) {
+	email = strings.ToLower(email)
+
+	user, err := s.repo.GetAccountByEmail(email)
+	if err != nil {
+		return "", &PasswordResetNotFoundError{}
+	}
+
+	reset, err := s.repo.GetActivePasswordResetByUserID(user.Id)
+	if err != nil {
+		return "", &PasswordResetNotFoundError{}
+	}
+
+	if reset.OTPVerified {
+		return "", &PasswordResetNotFoundError{}
+	}
+
+	if time.Now().After(reset.OTPExpiresAt) {
+		return "", &PasswordResetExpiredError{}
+	}
+
+	if reset.Attempts >= passwordResetMaxAttempts {
+		return "", &PasswordResetMaxAttemptsError{}
+	}
+
+	if !hashing.VerifyPassword(reset.OTPHash, code) {
+		if err := s.repo.IncrementPasswordResetAttempts(reset.Id); err != nil {
+			logger.Logger.Errorf("VerifyPasswordResetCode: failed to increment attempts for reset=%s: %v", reset.Id, err)
+		}
+		remaining := passwordResetMaxAttempts - (reset.Attempts + 1)
+		if remaining <= 0 {
+			return "", &PasswordResetMaxAttemptsError{}
+		}
+		return "", &InvalidPasswordResetCodeError{}
+	}
+
+	tokenPlain, tokenHash, err := generateResetToken()
+	if err != nil {
+		logger.Logger.Errorf("VerifyPasswordResetCode: failed to generate reset token for user=%s: %v", user.Id, err)
+		return "", &AccountFailedToCreateTokenError{}
+	}
+
+	resetTokenExpiresAt := time.Now().Add(passwordResetTokenExpiry)
+	if err := s.repo.MarkPasswordResetOTPVerified(reset.Id, tokenHash, resetTokenExpiresAt); err != nil {
+		logger.Logger.Errorf("VerifyPasswordResetCode: failed to mark OTP verified for reset=%s: %v", reset.Id, err)
+		return "", &AccountFailedToCreateTokenError{}
+	}
+
+	logger.Logger.Infof("VerifyPasswordResetCode: OTP verified, reset token issued for user=%s", user.Id)
+	return tokenPlain, nil
+}
+
+// ResetPassword validates the reset token, updates the password, and revokes all active sessions.
+func (s *accountService) ResetPassword(resetToken string, newPassword string) error {
+	sum := sha256.Sum256([]byte(resetToken))
+	tokenHash := hex.EncodeToString(sum[:])
+
+	reset, err := s.repo.GetPasswordResetByTokenHash(tokenHash)
+	if err != nil {
+		return &PasswordResetNotFoundError{}
+	}
+
+	if reset.ResetTokenExpiresAt == nil || time.Now().After(*reset.ResetTokenExpiresAt) {
+		return &PasswordResetTokenExpiredError{}
+	}
+
+	if err := validator.IsValidPassword(newPassword); err != nil {
+		if _, ok := err.(*validator.EmptyPasswordError); ok {
+			return &AccountInvalidFormat{Msg: "Empty password"}
+		}
+		if _, ok := err.(*validator.PasswordTooShortError); ok {
+			return &AccountInvalidFormat{Msg: "Password is too short"}
+		}
+		if _, ok := err.(*validator.PasswordNoLetterError); ok {
+			return &AccountInvalidFormat{Msg: "Password must contain at least one letter"}
+		}
+		if _, ok := err.(*validator.PasswordNoNumberError); ok {
+			return &AccountInvalidFormat{Msg: "Password must contain at least one number"}
+		}
+		return &AccountInvalidFormat{Msg: "Invalid password"}
+	}
+
+	hashedPassword, err := hashing.HashPassword(newPassword)
+	if err != nil {
+		return &AccountFailedToCreateError{}
+	}
+
+	if err := s.repo.UpdatePassword(reset.UserId, hashedPassword); err != nil {
+		logger.Logger.Errorf("ResetPassword: failed to update password for user=%s: %v", reset.UserId, err)
+		return &AccountFailedToCreateError{}
+	}
+
+	// Invalidate all reset records for this user (including the current one).
+	if err := s.repo.InvalidateAllPasswordResets(reset.UserId); err != nil {
+		logger.Logger.Warnf("ResetPassword: failed to invalidate password resets for user=%s: %v", reset.UserId, err)
+	}
+
+	// Rotate refresh_token_updated_at to force relogin on all devices.
+	if err := s.repo.UpdateRefreshTokenUpdatedAt(reset.UserId, time.Now()); err != nil {
+		logger.Logger.Errorf("ResetPassword: failed to revoke sessions for user=%s: %v", reset.UserId, err)
+	}
+
+	logger.Logger.Infof("ResetPassword: password reset completed for user=%s", reset.UserId)
+	return nil
 }

--- a/internal/authentication-service/services/account.go
+++ b/internal/authentication-service/services/account.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	mathrand "math/rand"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/FeedTheRealm-org/core-service/config"
@@ -23,57 +22,15 @@ import (
 )
 
 const (
-	passwordResetOTPExpiry        = 10 * time.Minute
-	passwordResetTokenExpiry      = 15 * time.Minute
-	passwordResetMaxAttempts      = 5
-	forgotPasswordRateLimitReqs   = 3
-	forgotPasswordRateLimitWindow = 15 * time.Minute
+	passwordResetOTPExpiry   = 10 * time.Minute
+	passwordResetTokenExpiry = 15 * time.Minute
+	passwordResetMaxAttempts = 5
 )
 
-type rateLimiter struct {
-	mu       sync.Mutex
-	requests map[string][]time.Time
-	maxReqs  int
-	window   time.Duration
-}
-
-func newRateLimiter(maxReqs int, window time.Duration) *rateLimiter {
-	return &rateLimiter{
-		requests: make(map[string][]time.Time),
-		maxReqs:  maxReqs,
-		window:   window,
-	}
-}
-
-func (r *rateLimiter) Allow(key string) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	now := time.Now()
-	cutoff := now.Add(-r.window)
-
-	existing := r.requests[key]
-	filtered := existing[:0]
-	for _, t := range existing {
-		if t.After(cutoff) {
-			filtered = append(filtered, t)
-		}
-	}
-
-	if len(filtered) >= r.maxReqs {
-		r.requests[key] = filtered
-		return false
-	}
-
-	r.requests[key] = append(filtered, now)
-	return true
-}
-
 type accountService struct {
-	conf              *config.Config
-	repo              repositories.AccountRepository
-	jwt               *session.JWTManager
-	forgotRateLimiter *rateLimiter
+	conf *config.Config
+	repo repositories.AccountRepository
+	jwt  *session.JWTManager
 }
 
 type AccountNotFoundError struct{}
@@ -209,10 +166,9 @@ func (s *accountService) seedAdminAccount(conf *config.Config) {
 
 func NewAccountService(conf *config.Config, repo repositories.AccountRepository, jwtManager *session.JWTManager) AccountService {
 	newAccountService := &accountService{
-		conf:              conf,
-		repo:              repo,
-		jwt:               jwtManager,
-		forgotRateLimiter: newRateLimiter(forgotPasswordRateLimitReqs, forgotPasswordRateLimitWindow),
+		conf: conf,
+		repo: repo,
+		jwt:  jwtManager,
 	}
 
 	newAccountService.seedAdminAccount(conf)
@@ -516,11 +472,6 @@ func generateResetToken() (plaintext string, tokenHash string, err error) {
 // Returns ("", nil) when the email is unknown or rate-limited — caller must treat all cases as success.
 func (s *accountService) ForgotPassword(email string) (string, error) {
 	email = strings.ToLower(email)
-
-	if !s.forgotRateLimiter.Allow(email) {
-		logger.Logger.Warnf("ForgotPassword: rate limit exceeded for email=%s", email)
-		return "", nil
-	}
 
 	user, err := s.repo.GetAccountByEmail(email)
 	if err != nil {

--- a/internal/authentication-service/services/account.go
+++ b/internal/authentication-service/services/account.go
@@ -578,6 +578,7 @@ func (s *accountService) VerifyPasswordResetCode(email string, code string) (str
 	if !hashing.VerifyPassword(reset.OTPHash, code) {
 		if err := s.repo.IncrementPasswordResetAttempts(reset.Id); err != nil {
 			logger.Logger.Errorf("VerifyPasswordResetCode: failed to increment attempts for reset=%s: %v", reset.Id, err)
+			return "", &PasswordResetMaxAttemptsError{}
 		}
 		remaining := passwordResetMaxAttempts - (reset.Attempts + 1)
 		if remaining <= 0 {

--- a/internal/authentication-service/services/email_sender.go
+++ b/internal/authentication-service/services/email_sender.go
@@ -18,6 +18,8 @@ const brevoSendEmailURL = "https://api.brevo.com/v3/smtp/email"
 const filepathTemplates = "templates"
 const templateVerificationEmail = "verification_email.html"
 const templateName = "verification_email"
+const templatePasswordResetEmail = "password_reset_email.html"
+const templateNamePasswordReset = "password_reset_email"
 
 // EmailTemplateData holds the data for email templates
 type EmailTemplateData struct {
@@ -100,13 +102,8 @@ func createRequestForSendEmail(payload *bytes.Buffer, apiKey string) (*http.Requ
 	return req, nil
 }
 
-func (s *emailSenderService) SendVerificationEmail(toEmail string, verifyCode string) error {
-	data, err := createPayloadForSendEmail(s.conf.EmailSenderAddress, toEmail, verifyCode, s.conf.EmailLogoURL)
-	if err != nil {
-		return err
-	}
-
-	req, err := createRequestForSendEmail(data, s.conf.BrevoAPIKey)
+func (s *emailSenderService) sendEmail(payload *bytes.Buffer, logTag string) error {
+	req, err := createRequestForSendEmail(payload, s.conf.BrevoAPIKey)
 	if err != nil {
 		return err
 	}
@@ -119,13 +116,64 @@ func (s *emailSenderService) SendVerificationEmail(toEmail string, verifyCode st
 
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			logger.Logger.Warnf("SendVerificationEmail: failed to close response body: %v", cerr)
+			logger.Logger.Warnf("%s: failed to close response body: %v", logTag, cerr)
 		}
 	}()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to send verification email, status code: %d", resp.StatusCode)
+		return fmt.Errorf("failed to send email (%s), status code: %d", logTag, resp.StatusCode)
 	}
 
 	return nil
+}
+
+func (s *emailSenderService) SendVerificationEmail(toEmail string, verifyCode string) error {
+	data, err := createPayloadForSendEmail(s.conf.EmailSenderAddress, toEmail, verifyCode, s.conf.EmailLogoURL)
+	if err != nil {
+		return err
+	}
+	return s.sendEmail(data, "SendVerificationEmail")
+}
+
+func (s *emailSenderService) SendPasswordResetEmail(toEmail string, otpCode string) error {
+	templatePath := filepath.Join(filepathTemplates, templatePasswordResetEmail)
+	templateContent, err := os.ReadFile(templatePath)
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New(templateNamePasswordReset).Parse(string(templateContent))
+	if err != nil {
+		return err
+	}
+
+	data := EmailTemplateData{
+		VerifyCode: otpCode,
+		ToEmail:    toEmail,
+		LogoURL:    s.conf.EmailLogoURL,
+	}
+
+	var htmlBuffer bytes.Buffer
+	if err := tmpl.Execute(&htmlBuffer, data); err != nil {
+		return err
+	}
+
+	emailData := map[string]interface{}{
+		"sender": map[string]string{
+			"name":  "Feed The Realm",
+			"email": s.conf.EmailSenderAddress,
+		},
+		"to": []map[string]string{
+			{"email": toEmail},
+		},
+		"subject":     "Feed The Realm - Password Reset Code",
+		"htmlContent": htmlBuffer.String(),
+	}
+
+	jsonData, err := json.Marshal(emailData)
+	if err != nil {
+		return err
+	}
+
+	return s.sendEmail(bytes.NewBuffer(jsonData), "SendPasswordResetEmail")
 }

--- a/internal/authentication-service/services/interface_account.go
+++ b/internal/authentication-service/services/interface_account.go
@@ -13,4 +13,9 @@ type AccountService interface {
 	VerifyAccount(email string, code string) (bool, error)
 	RefreshVerificationCode(email string) (string, error)
 	RefreshToken(email string) (string, string, error)
+
+	// Password reset
+	ForgotPassword(email string) (otpCode string, err error)
+	VerifyPasswordResetCode(email string, code string) (resetToken string, err error)
+	ResetPassword(resetToken string, newPassword string) error
 }

--- a/internal/authentication-service/services/interface_email_sender.go
+++ b/internal/authentication-service/services/interface_email_sender.go
@@ -2,4 +2,5 @@ package services
 
 type EmailSenderService interface {
 	SendVerificationEmail(toEmail string, verifyCode string) error
+	SendPasswordResetEmail(toEmail string, otpCode string) error
 }

--- a/migrations/authentication-service/06_create_password_resets_table.down.sql
+++ b/migrations/authentication-service/06_create_password_resets_table.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS idx_password_resets_reset_token_hash;
+DROP INDEX IF EXISTS idx_password_resets_user_id;
+DROP TABLE IF EXISTS password_resets;
+
+COMMIT;

--- a/migrations/authentication-service/06_create_password_resets_table.up.sql
+++ b/migrations/authentication-service/06_create_password_resets_table.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE password_resets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    otp_hash TEXT NOT NULL,
+    reset_token_hash TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    otp_expires_at TIMESTAMPTZ NOT NULL,
+    reset_token_expires_at TIMESTAMPTZ,
+    otp_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    used BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_password_reset_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_password_resets_user_id ON password_resets(user_id);
+CREATE INDEX idx_password_resets_reset_token_hash ON password_resets(reset_token_hash);
+
+COMMIT;

--- a/templates/password_reset_email.html
+++ b/templates/password_reset_email.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Reset your password</title>
+    <style>
+      body,
+      table,
+      td {
+        margin: 0;
+        padding: 0;
+        border: 0;
+      }
+      img {
+        border: 0;
+        display: block;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+      body {
+        width: 100% !important;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        background: #ffffff;
+        color: #222;
+      }
+      .ExternalClass {
+        width: 100%;
+      }
+      @media only screen and (max-width: 600px) {
+        .container {
+          width: 100% !important;
+        }
+        .content {
+          padding: 20px !important;
+        }
+        .footer-box {
+          padding: 18px !important;
+        }
+        .headline {
+          font-size: 22px !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td align="center" style="padding: 28px 12px">
+          <table
+            class="container"
+            width="600"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="max-width: 600px"
+          >
+            <tr>
+              <td align="center" style="padding: 10px 18px">
+                <h1
+                  class="headline"
+                  style="
+                    margin: 0;
+                    font-weight: 600;
+                    font-size: 28px;
+                    color: #111827;
+                  "
+                >
+                  Feed The Realm - Reset your password
+                </h1>
+                <img
+                  src="{{.LogoURL}}"
+                  alt="Feed The Realm Logo"
+                  style="
+                    max-width: 150px;
+                    border-radius: 12%;
+                    margin: 20px auto;
+                    display: block;
+                  "
+                />
+              </td>
+            </tr>
+
+            <tr>
+              <td
+                class="content"
+                style="
+                  padding: 18px 28px 28px 28px;
+                  text-align: center;
+                  color: #374151;
+                "
+              >
+                <p
+                  style="margin: 0 0 10px 0; font-size: 15px; line-height: 1.5"
+                >
+                  Your password reset code for
+                  <strong
+                    style="
+                      background: #fff2b8;
+                      padding: 0 4px;
+                      border-radius: 2px;
+                    "
+                    >Feed the Realm</strong
+                  >
+                  is:
+                </p>
+
+                <div
+                  style="
+                    display: inline-block;
+                    margin-top: 14px;
+                    padding: 12px 18px;
+                    border-radius: 8px;
+                    background: #f3f4f6;
+                    font-weight: 700;
+                    font-size: 24px;
+                    letter-spacing: 4px;
+                    color: #0f172a;
+                  "
+                >
+                  {{.VerifyCode}}
+                </div>
+
+                <p style="margin: 18px 0 0 0; font-size: 13px; color: #6b7280">
+                  This code expires in <strong>10 minutes</strong> and can only be used once.
+                </p>
+
+                <p style="margin: 10px 0 0 0; font-size: 13px; color: #dc2626; font-weight: 600;">
+                  If you did not request a password reset, please ignore this email. Your password will not change.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding: 0 28px 28px 28px">
+                <table
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  role="presentation"
+                  style="
+                    background: #f3f6f9;
+                    border-radius: 6px;
+                    overflow: hidden;
+                  "
+                >
+                  <tr>
+                    <td
+                      class="footer-box"
+                      style="padding: 22px; text-align: center"
+                    >
+                      <strong style="font-size: 16px; color: #0f172a"
+                        >Feed the Realm</strong
+                      ><br /><br />
+
+                      <div
+                        style="
+                          font-size: 13px;
+                          color: #6b7280;
+                          line-height: 1.5;
+                        "
+                      >
+                        Ciudad Autónoma de Buenos Aires, Argentina<br />
+                        This email was sent automatically.<br />
+                        You received this email because a password reset was requested for your account.
+                      </div>
+
+                      <div style="padding-top: 12px">
+                        This email was sent to {{.ToEmail}}
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td
+                style="
+                  text-align: center;
+                  font-size: 12px;
+                  color: #9ca3af;
+                  padding: 8px 0 28px 0;
+                "
+              >
+                &copy; Feed the Realm. All rights reserved.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
# Summary
Resolved this issue: https://github.com/FeedTheRealm-org/game/issues/320
- Refactored the AuthFlow Manager
- Added a new Password reset handle

# Related PRs
- https://github.com/FeedTheRealm-org/core-service/pull/88
- https://github.com/FeedTheRealm-org/shared-unity-package/pull/122
- https://github.com/FeedTheRealm-org/world-editor/pull/121
- https://github.com/FeedTheRealm-org/game/pull/334


# **AuthFlowManager — How it works**

`AuthFlowManager` is the single coordinator for all authentication screens. It lives on a parent GameObject with each auth panel as a child GameObject.

**Panel management**

Each panel (`Login`, `SignUp`, `VerifyNewAccount`, `AccountRecovery`) is registered in a `Dictionary<AuthPanel, GameObject>` at startup. `ShowPanel(AuthPanel)` deactivates the current panel and activates the requested one — only one panel is ever active at a time.

**Initialization**

On `Awake`, all panels are disabled and each one's `IAuth` component is initialized via `InitializeAuthComponent`, which injects the shared dependencies (`AuthService`, `Session`, `Logger`, and the manager itself) into each controller. This means controllers never need to hold serialized references to services — they receive everything through `IAuth.Initialize`.

**Flow completion**

- `AuthCompletion(message)` — called when login or signup succeeds. Disables all panels and fires `OnAuthComplete` with a success message for external listeners (e.g. the main menu UI) to react to.
- `PasswordResetCompletion(message)` — called when account recovery completes. Fires `OnPasswordResetComplete` without closing the flow, allowing the UI to show a confirmation before returning to login.
- `CancelAuth()` — called when the user closes any panel. Disables everything and fires `OnAuthCancelled`.

**AccountRecovery**

The recovery flow (forgot password → verify code → new password) is handled entirely inside a single `AccountRecoveryController` with 3 internal steps shown/hidden by the controller itself. From `AuthFlowManager`'s perspective it's just one panel — no extra states needed.