### PR TITLE
Bug-53.4: World Info before join world

### DIFF
--- a/internal/world-service/controllers/server_registry/server_registry.go
+++ b/internal/world-service/controllers/server_registry/server_registry.go
@@ -277,7 +277,6 @@ func (c *serverRegistryController) UpdatePlayerCount(ctx *gin.Context) {
 // @Summary      Get world player counts
 // @Description  Returns player counts per zone for a world.
 // @Tags         world-service
-// @Security     BearerAuth
 // @Produce      json
 // @Param        id path string true "World UUID"
 // @Success      200  {object}  dtos.PlayerCountsResponse
@@ -310,7 +309,6 @@ func (c *serverRegistryController) GetWorldPlayerCounts(ctx *gin.Context) {
 // @Summary      Get all world player counts
 // @Description  Returns player counts for all worlds.
 // @Tags         world-service
-// @Security     BearerAuth
 // @Produce      json
 // @Success      200  {array}  dtos.PlayerCountsResponse
 // @Failure      500  {object} dtos.ErrorResponse

--- a/internal/world-service/router/router.go
+++ b/internal/world-service/router/router.go
@@ -59,8 +59,8 @@ func SetupEndpointsForServiceRegistry(orchestratorGroup *gin.RouterGroup, db *co
 	orchestratorGroup.GET("/:id/zones/:zone_id/stop-job", middleware.AdminCheckMiddleware(), serverRegistryController.StopJob)
 	orchestratorGroup.GET("/:id/zones/:zone_id/address", serverRegistryController.GetServerAddress)
 	orchestratorGroup.POST("/:id/zones/:zone_id/players", middleware.ServerCheckMiddleware(), serverRegistryController.UpdatePlayerCount)
-	orchestratorGroup.GET("/:id/players", middleware.AdminCheckMiddleware(), serverRegistryController.GetWorldPlayerCounts)
-	orchestratorGroup.GET("/players", middleware.AdminCheckMiddleware(), serverRegistryController.GetAllWorldPlayerCounts)
+	orchestratorGroup.GET("/:id/players", serverRegistryController.GetWorldPlayerCounts)
+	orchestratorGroup.GET("/players", serverRegistryController.GetAllWorldPlayerCounts)
 	orchestratorGroup.POST("/webhook/servers/update", middleware.GithubOIDCCheck(ghv), serverRegistryController.UpdateServer)
 	orchestratorGroup.PUT("/:id/zones/:zone_id/status", middleware.ServerCheckMiddleware(), serverRegistryController.UpdateStatus)
 

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3612,11 +3612,6 @@ const docTemplate = `{
         },
         "/world/orchestrator/players": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Returns player counts for all worlds.",
                 "produces": [
                     "application/json"
@@ -3684,11 +3679,6 @@ const docTemplate = `{
         },
         "/world/orchestrator/{id}/players": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Returns player counts per zone for a world.",
                 "produces": [
                     "application/json"

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3605,11 +3605,6 @@
         },
         "/world/orchestrator/players": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Returns player counts for all worlds.",
                 "produces": [
                     "application/json"
@@ -3677,11 +3672,6 @@
         },
         "/world/orchestrator/{id}/players": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Returns player counts per zone for a world.",
                 "produces": [
                     "application/json"

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -3369,8 +3369,6 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/dtos.ErrorResponse'
-      security:
-      - BearerAuth: []
       summary: Get world player counts
       tags:
       - world-service
@@ -3583,8 +3581,6 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/dtos.ErrorResponse'
-      security:
-      - BearerAuth: []
       summary: Get all world player counts
       tags:
       - world-service


### PR DESCRIPTION
## Changes:

* Removed `AdminCheckMiddleware` from `GET /:id/players` and `GET /players`, making both player count endpoints publicly accessible without admin authentication