### PR TITLE
Bug: Errors create account

### DIFF
--- a/internal/authentication-service/controllers/account.go
+++ b/internal/authentication-service/controllers/account.go
@@ -81,9 +81,9 @@ func (ec *accountController) CreateAccount(c *gin.Context) {
 			return
 		}
 
-		if _, ok := err.(*services.AccountInvalidFormat); ok {
+		if fmtErr, ok := err.(*services.AccountInvalidFormat); ok {
 			logger.Logger.Infof("CreateAccount: invalid account format for email=%s: %v", req.Email, err)
-			_ = c.Error(errors.NewBadRequestError("The email address is not valid."))
+			_ = c.Error(errors.NewBadRequestError(fmtErr.Msg))
 			return
 		}
 

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -1949,6 +1949,12 @@ const docTemplate = `{
                         "name": "file",
                         "in": "formData",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Release notes",
+                        "name": "release_note",
+                        "in": "formData"
                     }
                 ],
                 "responses": {
@@ -4851,6 +4857,9 @@ const docTemplate = `{
                 "path": {
                     "type": "string"
                 },
+                "release_note": {
+                    "type": "string"
+                },
                 "updated_at": {
                     "type": "string"
                 },
@@ -5166,6 +5175,12 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "average_player_time": {
+                    "type": "integer"
+                },
+                "max_active_players": {
+                    "type": "integer"
+                },
+                "max_average_player_time": {
                     "type": "integer"
                 }
             }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1942,6 +1942,12 @@
                         "name": "file",
                         "in": "formData",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Release notes",
+                        "name": "release_note",
+                        "in": "formData"
                     }
                 ],
                 "responses": {
@@ -4844,6 +4850,9 @@
                 "path": {
                     "type": "string"
                 },
+                "release_note": {
+                    "type": "string"
+                },
                 "updated_at": {
                     "type": "string"
                 },
@@ -5159,6 +5168,12 @@
                     "type": "integer"
                 },
                 "average_player_time": {
+                    "type": "integer"
+                },
+                "max_active_players": {
+                    "type": "integer"
+                },
+                "max_average_player_time": {
                     "type": "integer"
                 }
             }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -183,6 +183,8 @@ definitions:
         type: string
       path:
         type: string
+      release_note:
+        type: string
       updated_at:
         type: string
       version:
@@ -386,6 +388,10 @@ definitions:
       active_players:
         type: integer
       average_player_time:
+        type: integer
+      max_active_players:
+        type: integer
+      max_average_player_time:
         type: integer
     type: object
   dtos.PricingInfoResponse:
@@ -1977,6 +1983,10 @@ paths:
         name: file
         required: true
         type: file
+      - description: Release notes
+        in: formData
+        name: release_note
+        type: string
       produces:
       - application/json
       responses:

--- a/tests/features/signup.feature
+++ b/tests/features/signup.feature
@@ -22,20 +22,20 @@ Feature: User Sign-Up
 
   Scenario: AC-4a Show error when the email format is invalid
     When a sign-up request is made with email "invalid-email" and password "StrongPass123!"
-    Then the response should include an error message "The email address is not valid."
+    Then the response should include an error message "Invalid email"
 
   Scenario: AC-4b Show error when the email domain is invalid
     When a sign-up request is made with email "user@invalid" and password "StrongPass123!"
-    Then the response should include an error message "The email address is not valid."
+    Then the response should include an error message "Invalid email"
 
   Scenario: AC-5a Show error when the password is too short
     When a sign-up request is made with email "shortpass@example.com" and password "Ab12"
-    Then the response should include an error message "The email address is not valid."
+    Then the response should include an error message "Password is too short"
 
   Scenario: AC-5b Show error when the password has no numbers
     When a sign-up request is made with email "nonumeric@example.com" and password "PasswordOnly"
-    Then the response should include an error message "The email address is not valid."
+    Then the response should include an error message "Password must contain at least one number"
 
   Scenario: AC-5c Show error when the password has no letters
     When a sign-up request is made with email "noletters@example.com" and password "12345678"
-    Then the response should include an error message "The email address is not valid."
+    Then the response should include an error message "Password must contain at least one letter"


### PR DESCRIPTION
## Changes:

* Updated `CreateAccount` error handler to forward the specific message from `AccountInvalidFormat` instead of a hardcoded string
* Updated Swagger docs to add `release_note` form field to the model upload endpoint, and `max_active_players` and `max_average_player_time` fields to the world stats DTO