### PR TITLE
Bug-113: Publish doesnt update the server

### DIFF
--- a/internal/world-service/services/zones/zones.go
+++ b/internal/world-service/services/zones/zones.go
@@ -37,7 +37,18 @@ func (zs *zonesService) GetWorld(worldID uuid.UUID) (*models.WorldData, error) {
 }
 
 func (zs *zonesService) PublishZone(worldID uuid.UUID, zoneID int, zoneData []byte) (*models.WorldZone, error) {
-	return zs.worldRepository.UpsertWorldZone(worldID, zoneID, zoneData)
+	zone, err := zs.worldRepository.UpsertWorldZone(worldID, zoneID, zoneData)
+	if err != nil {
+		return nil, err
+	}
+
+	if zone.IsActive {
+		if err := zs.serverRegistryService.StartNewJob(worldID, zoneID, true); err != nil {
+			return nil, err
+		}
+	}
+
+	return zone, nil
 }
 
 func (zs *zonesService) ActivateZone(worldID uuid.UUID, zoneID int) error {


### PR DESCRIPTION
## Changes

* Updated `ZonesService.PublishZone` to restart the Nomad job via `serverRegistryService.StartNewJob` after upserting the zone data, but only when the zone is already active

## How to test

1. Publish a world
2. Activate it
3. Change things on world
4. Re-publish world