### PR TITLE
US-97: Extend canceled subscription until expiration date

### DIFF
--- a/internal/payment-service/controllers/zones-subscriptions/controller.go
+++ b/internal/payment-service/controllers/zones-subscriptions/controller.go
@@ -6,6 +6,7 @@ type ZonesSubscriptionsController interface {
 	CreateCheckoutSession(c *gin.Context)
 	UpdateSlots(c *gin.Context)
 	CancelSubscription(c *gin.Context)
+	ReactivateSubscription(c *gin.Context)
 	GetStatus(c *gin.Context)
 	GetPricingInfo(c *gin.Context)
 	CheckInternalAvailability(c *gin.Context)

--- a/internal/payment-service/controllers/zones-subscriptions/zones_subscriptions.go
+++ b/internal/payment-service/controllers/zones-subscriptions/zones_subscriptions.go
@@ -155,6 +155,44 @@ func (zc *subscriptionController) CancelSubscription(c *gin.Context) {
 	common_handlers.HandleSuccessResponse(c, 200, res)
 }
 
+// ReactivateSubscription godoc
+// @Summary      Reactivate subscription
+// @Description  Reactivates the user's cancelled subscription.
+// @Tags         payment-service-subscriptions
+// @Security     BearerAuth
+// @Produce      json
+// @Success      200      {object}  dtos.SubscriptionStatusResponse
+// @Failure      400      {object}  dtos.ErrorResponse
+// @Failure      401      {object}  dtos.ErrorResponse
+// @Failure      500      {object}  dtos.ErrorResponse
+// @Router       /subscriptions/reactivate [post]
+func (zc *subscriptionController) ReactivateSubscription(c *gin.Context) {
+	userID, err := common_handlers.GetUserIDFromSession(c)
+	if err != nil {
+		logger.Logger.Error("Failed to parse user_id from context: " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Invalid user_id in context"))
+		return
+	}
+
+	sub, err := zc.zonesSubscriptionsService.ReactivateSubscription(userID)
+	if err != nil {
+		logger.Logger.Error("Failed to reactivate subscription for user " + userID.String() + ": " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Failed to reactivate subscription: " + err.Error()))
+		return
+	}
+
+	amountDue, _ := sub.AmountDue.Float64()
+
+	res := &dtos.SubscriptionStatusResponse{
+		Slots:           sub.TotalSlots,
+		UsedSlots:       sub.UsedSlots,
+		Status:          string(sub.Status),
+		NextBillingDate: sub.NextBillingDate,
+		AmountDue:       amountDue,
+	}
+	common_handlers.HandleSuccessResponse(c, 200, res)
+}
+
 // GetStatus godoc
 // @Summary      Get subscription status
 // @Description  Retrieves the active subscription status for the user.

--- a/internal/payment-service/router/router.go
+++ b/internal/payment-service/router/router.go
@@ -72,6 +72,7 @@ func SetupSubscriptionsServiceRouter(conf *config.Config, db *config.DB, subscri
 
 	// External / user-facing subscription routes
 	subscriptionGroup.POST("/checkout", zonesSubscriptionsController.CreateCheckoutSession)
+	subscriptionGroup.POST("/reactivate", zonesSubscriptionsController.ReactivateSubscription)
 	subscriptionGroup.PUT("/slots", zonesSubscriptionsController.UpdateSlots)
 	subscriptionGroup.GET("/status", zonesSubscriptionsController.GetStatus)
 	subscriptionGroup.GET("/pricing", zonesSubscriptionsController.GetPricingInfo)

--- a/internal/payment-service/services/zones-subscriptions/service.go
+++ b/internal/payment-service/services/zones-subscriptions/service.go
@@ -15,5 +15,6 @@ type SubscriptionService interface {
 	CheckAvalibility(userID uuid.UUID) (bool, int, error)
 	CreateCheckoutSession(userID uuid.UUID, email string, slots int, successUrl string, cancelUrl string) (string, error)
 	CancelSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error)
+	ReactivateSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error)
 	HandleWebhook(payload []byte, signature string) error
 }

--- a/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
+++ b/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
@@ -241,7 +241,13 @@ func (zs *zoneSubscriptionService) GetByUserID(userID uuid.UUID) (*models.ZonesS
 		logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s: %v", userID, err)
 		return nil, err
 	}
+
 	sub.AmountDue = amountDue
+
+	if _, err = zs.repo.Update(sub); err != nil {
+		logger.Logger.Errorf("Failed to persist amount due for user %s: %v", userID, err)
+		return nil, err
+	}
 
 	return sub, nil
 }

--- a/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
+++ b/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 
@@ -38,17 +39,37 @@ type zoneSubscriptionService struct {
 }
 
 const DATE_FORMAT = "2006-01-02 15:04:05 MST"
+const MIN_PRORATED_AMOUNT_CENTS = 60
+const StatusPendingCancellation = "pending_cancellation"
 
 func NewSubscriptionService(conf *config.Config, repo zones_subscriptions.ZonesSubscriptionsRepository, emailSender email_sender.EmailSenderService) SubscriptionService {
 	stripe.Key = conf.Stripe.StripeApiKey
 	return &zoneSubscriptionService{conf: conf, repo: repo, emailSender: emailSender}
 }
 
+func (zs *zoneSubscriptionService) calculateProratedAmount(slots int) int64 {
+	pricePerSlot := int64(zs.conf.Stripe.StripeZonePrice * 100)
+
+	now := time.Now().UTC()
+	cycleStart := zs.currentBillingDate()
+
+	nowUnix := now.Unix()
+	billingEnd := zs.nextBillingDate().Unix()
+	cycleStartUnix := cycleStart.Unix()
+
+	ratio := float64(billingEnd-nowUnix) / float64(billingEnd-cycleStartUnix)
+	totalAmount := pricePerSlot * int64(slots)
+
+	return int64(math.Floor(float64(totalAmount) * ratio))
+}
+
 func (zs *zoneSubscriptionService) CreateCheckoutSession(userID uuid.UUID, email string, slots int, successURL string, cancelURL string) (string, error) {
 	logger.Logger.Infof("Creating checkout session for user %s (%d slots)", userID, slots)
 
 	sub, err := zs.repo.GetByUserID(userID)
-	if err == nil && sub != nil && sub.Status == stripe.SubscriptionStatusActive {
+	if err != nil {
+		sub = nil
+	} else if sub.Status == stripe.SubscriptionStatusActive {
 		return "", fmt.Errorf("user %s already has an active subscription", userID)
 	}
 
@@ -56,6 +77,8 @@ func (zs *zoneSubscriptionService) CreateCheckoutSession(userID uuid.UUID, email
 	if err != nil {
 		return "", err
 	}
+
+	proratedAmount := zs.calculateProratedAmount(slots)
 
 	stripeParamsPriceData := &stripe.CheckoutSessionLineItemPriceDataParams{
 		Currency: stripe.String("usd"),
@@ -73,11 +96,30 @@ func (zs *zoneSubscriptionService) CreateCheckoutSession(userID uuid.UUID, email
 		Quantity:  stripe.Int64((int64)(slots)),
 	}
 
+	lineItems := []*stripe.CheckoutSessionLineItemParams{stripeParamsSession}
+
+	if proratedAmount < MIN_PRORATED_AMOUNT_CENTS {
+		adjustment := MIN_PRORATED_AMOUNT_CENTS - proratedAmount
+
+		proratedItem := &stripe.CheckoutSessionLineItemParams{
+			PriceData: &stripe.CheckoutSessionLineItemPriceDataParams{
+				Currency: stripe.String("usd"),
+				ProductData: &stripe.CheckoutSessionLineItemPriceDataProductDataParams{
+					Name: stripe.String("Minimum charge adjustment"),
+				},
+				UnitAmount: stripe.Int64(adjustment),
+			},
+			Quantity: stripe.Int64(1),
+		}
+
+		lineItems = append(lineItems, proratedItem)
+	}
+
 	params := &stripe.CheckoutSessionParams{
 		SuccessURL: stripe.String(successURL),
 		CancelURL:  stripe.String(cancelURL),
 		Mode:       stripe.String(string(stripe.CheckoutSessionModeSubscription)),
-		LineItems:  []*stripe.CheckoutSessionLineItemParams{stripeParamsSession},
+		LineItems:  lineItems,
 		Customer:   stripe.String(sub.StripeCustomerID),
 		SubscriptionData: &stripe.CheckoutSessionSubscriptionDataParams{
 			BillingCycleAnchor: stripe.Int64(zs.nextBillingDate().Unix()),
@@ -113,6 +155,11 @@ func (zs *zoneSubscriptionService) UpdateSlots(userID uuid.UUID, newSlots int) (
 	if sub.StripeSubscriptionID == "" {
 		return nil, fmt.Errorf("subscription not found for user")
 	}
+
+	if sub.Status == StatusPendingCancellation {
+		return nil, fmt.Errorf("cannot update slots for subscription pending cancellation")
+	}
+
 	if sub.Status != stripe.SubscriptionStatusActive {
 		return nil, fmt.Errorf("subscription is not active")
 	}
@@ -189,16 +236,12 @@ func (zs *zoneSubscriptionService) GetByUserID(userID uuid.UUID) (*models.ZonesS
 		return nil, err
 	}
 
-	amountDue, err := zs.getNextInvoiceAmount(userID)
+	amountDue, err := zs.getNextInvoiceAmount(sub)
 	if err != nil {
-		logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription deletion: %v", userID, err)
+		logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s: %v", userID, err)
 		return nil, err
 	}
 	sub.AmountDue = amountDue
-
-	if _, err = zs.repo.Update(sub); err != nil {
-		return nil, err
-	}
 
 	return sub, nil
 }
@@ -209,7 +252,7 @@ func (zs *zoneSubscriptionService) CheckAvalibility(userID uuid.UUID) (bool, int
 		return false, 0, err
 	}
 
-	if sub.Status != stripe.SubscriptionStatusActive {
+	if sub.Status != stripe.SubscriptionStatusActive && sub.Status != StatusPendingCancellation {
 		return false, 0, nil
 	}
 
@@ -217,7 +260,7 @@ func (zs *zoneSubscriptionService) CheckAvalibility(userID uuid.UUID) (bool, int
 }
 
 func (zs *zoneSubscriptionService) CancelSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error) {
-	logger.Logger.Infof("Cancelling subscription for user %s", userID)
+	logger.Logger.Infof("Scheduling cancellation at period end for user %s", userID)
 
 	sub, err := zs.repo.GetByUserID(userID)
 	if err != nil {
@@ -232,28 +275,52 @@ func (zs *zoneSubscriptionService) CancelSubscription(userID uuid.UUID) (*models
 		return nil, fmt.Errorf("subscription is not active")
 	}
 
-	if sub.UsedSlots > 0 {
-		return nil, fmt.Errorf("cannot cancel subscription because %d slots are currently in use. Please delete your zones first", sub.UsedSlots)
-	}
-
-	params := &stripe.SubscriptionCancelParams{
-		InvoiceNow: stripe.Bool(true),
-		Prorate:    stripe.Bool(true),
-	}
-
-	_, err = subscription.Cancel(sub.StripeSubscriptionID, params)
+	_, err = subscription.Update(sub.StripeSubscriptionID, &stripe.SubscriptionParams{
+		CancelAtPeriodEnd: stripe.Bool(true),
+	})
 	if err != nil {
-		logger.Logger.Errorf("Failed to cancel Stripe subscription %s for user %s: %v", sub.StripeSubscriptionID, userID, err)
+		logger.Logger.Errorf("Failed to schedule cancellation for Stripe subscription %s for user %s: %v", sub.StripeSubscriptionID, userID, err)
 		return nil, err
 	}
 
-	sub.Status = stripe.SubscriptionStatusCanceled
+	sub.Status = StatusPendingCancellation
 	if _, err = zs.repo.Update(sub); err != nil {
-		logger.Logger.Errorf("Failed to update DB status to canceled for user %s: %v", userID, err)
+		logger.Logger.Errorf("Failed to update DB status to %s for user %s: %v", StatusPendingCancellation, userID, err)
 		return nil, err
 	}
 
-	logger.Logger.Infof("Subscription for user %s cancelled", userID)
+	logger.Logger.Infof("Subscription for user %s scheduled to cancel at period end", userID)
+	return sub, nil
+}
+
+func (zs *zoneSubscriptionService) ReactivateSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error) {
+	sub, err := zs.repo.GetByUserID(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if sub.StripeSubscriptionID == "" {
+		return nil, fmt.Errorf("subscription not found for user")
+	}
+	if sub.Status != StatusPendingCancellation {
+		return nil, fmt.Errorf("subscription is not pending cancellation")
+	}
+
+	_, err = subscription.Update(sub.StripeSubscriptionID, &stripe.SubscriptionParams{
+		CancelAtPeriodEnd: stripe.Bool(false),
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to undo cancellation for Stripe subscription %s for user %s: %v", sub.StripeSubscriptionID, userID, err)
+		return nil, err
+	}
+
+	sub.Status = stripe.SubscriptionStatusActive
+	if _, err = zs.repo.Update(sub); err != nil {
+		logger.Logger.Errorf("Failed to update DB status to active for user %s: %v", userID, err)
+		return nil, err
+	}
+
+	logger.Logger.Infof("Subscription for user %s reactivated (cancellation undone)", userID)
 	return sub, nil
 }
 
@@ -326,7 +393,7 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		dbSub.NextBillingDate = zs.nextBillingDate()
 		dbSub.TotalSlots = int(stripeSub.Items.Data[0].Quantity)
 
-		amountDue, err := zs.getNextInvoiceAmount(dbSub.UserID)
+		amountDue, err := zs.getNextInvoiceAmount(dbSub)
 		if err != nil {
 			logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription creation: %v", dbSub.UserID, err)
 			return err
@@ -385,7 +452,13 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		}
 
 		dbSub.StripeSubscriptionID = stripeSub.ID
-		dbSub.Status = stripeSub.Status
+
+		if stripeSub.Status == stripe.SubscriptionStatusActive && stripeSub.CancelAtPeriodEnd {
+			dbSub.Status = StatusPendingCancellation
+		} else {
+			dbSub.Status = stripeSub.Status
+		}
+
 		dbSub.NextBillingDate = zs.nextBillingDate()
 
 		oldAmountDue := dbSub.AmountDue
@@ -395,7 +468,7 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		dbSub.TotalSlots = int(stripeSub.Items.Data[0].Quantity)
 
 		if stripeSub.Status == stripe.SubscriptionStatusActive {
-			amountDue, err := zs.getNextInvoiceAmount(dbSub.UserID)
+			amountDue, err := zs.getNextInvoiceAmount(dbSub)
 			if err != nil {
 				logger.Logger.Errorf("Failed to fetch upcoming invoice for user %s during subscription update: %v", dbSub.UserID, err)
 				return err
@@ -431,7 +504,7 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 			return err
 		}
 
-		logger.Logger.Infof("Handled subscription.updated for user %s, status: %s", userID, stripeSub.Status)
+		logger.Logger.Infof("Handled subscription.updated for user %s, status: %s", userID, dbSub.Status)
 		return nil
 	case "customer.subscription.deleted":
 		var stripeSub stripe.Subscription
@@ -452,6 +525,8 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 		email, emailOk := stripeSub.Metadata["email"]
 
 		dbSub.Status = stripeSub.Status
+		dbSub.StripeCustomerID = ""
+		dbSub.StripeSubscriptionID = ""
 		dbSub.TotalSlots = int(stripeSub.Items.Data[0].Quantity)
 		dbSub.AmountDue = decimal.Zero
 
@@ -579,14 +654,11 @@ func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature strin
 	}
 }
 
-func (zs *zoneSubscriptionService) getNextInvoiceAmount(userID uuid.UUID) (decimal.Decimal, error) {
-	sub, err := zs.repo.GetByUserID(userID)
-	if err != nil {
-		return decimal.Zero, err
-	}
-
-	if (sub.StripeSubscriptionID == "" && sub.Status == "pending") || sub.Status == stripe.SubscriptionStatusCanceled {
-		return decimal.NewFromFloat(zs.conf.Stripe.StripeZonePrice).Mul(decimal.NewFromInt(int64(sub.TotalSlots))), nil
+func (zs *zoneSubscriptionService) getNextInvoiceAmount(sub *models.ZonesSubscriptions) (decimal.Decimal, error) {
+	if (sub.StripeSubscriptionID == "" && sub.Status == "pending") ||
+		sub.Status == stripe.SubscriptionStatusCanceled ||
+		sub.Status == StatusPendingCancellation {
+		return decimal.Zero, nil
 	}
 
 	inv, err := stripe_invoice.CreatePreview(&stripe.InvoiceCreatePreviewParams{
@@ -620,6 +692,20 @@ func (zs *zoneSubscriptionService) ensureCustomer(
 		return nil, err
 	}
 
+	if existingSub != nil {
+		existingSub.StripeCustomerID = c.ID
+		existingSub.TotalSlots = slots
+		existingSub.AmountDue = decimal.NewFromFloat(zs.conf.Stripe.StripeZonePrice).Mul(decimal.NewFromInt(int64(slots)))
+		existingSub.Status = "pending"
+		existingSub.NextBillingDate = zs.nextBillingDate()
+		if existingSub, err = zs.repo.Update(existingSub); err != nil {
+			logger.Logger.Errorf("Failed to update subscription DB record for user %s: %v", userID, err)
+			return nil, err
+		}
+		logger.Logger.Infof("Re-created Stripe customer %s for user %s", c.ID, userID)
+		return existingSub, nil
+	}
+
 	sub = &models.ZonesSubscriptions{
 		UserID:           userID,
 		StripeCustomerID: c.ID,
@@ -635,6 +721,36 @@ func (zs *zoneSubscriptionService) ensureCustomer(
 
 	logger.Logger.Infof("Created Stripe customer %s for user %s", c.ID, userID)
 	return sub, nil
+}
+
+func (zs *zoneSubscriptionService) currentBillingDate() time.Time {
+	loc, err := time.LoadLocation(zs.conf.Stripe.StripeBillingTimezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	anchorDay := zs.conf.Stripe.StripeBillingAnchorDay
+
+	now := time.Now().In(loc)
+
+	candidate := time.Date(
+		now.Year(),
+		now.Month(),
+		anchorDay,
+		12, 0, 0, 0,
+		loc,
+	)
+
+	if candidate.After(now) {
+		candidate = time.Date(
+			now.Year(),
+			now.Month()-1,
+			anchorDay,
+			12, 0, 0, 0,
+			loc,
+		)
+	}
+
+	return candidate.UTC()
 }
 
 func (zs *zoneSubscriptionService) nextBillingDate() time.Time {

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_service_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_service_test.go
@@ -154,7 +154,7 @@ func TestSubscriptionService_GetByUserID_PendingStatus(t *testing.T) {
 	sub, err := service.GetByUserID(userID)
 	assert.NoError(t, err)
 	assert.Equal(t, userID, sub.UserID)
-	assert.True(t, sub.AmountDue.GreaterThan(decimal.Zero))
+	assert.True(t, sub.AmountDue.Equal(decimal.Zero))
 }
 
 func TestSubscriptionService_GetPricingInfo(t *testing.T) {
@@ -185,14 +185,15 @@ func TestSubscriptionService_UpdateUsedSlots_ExceedsTotal(t *testing.T) {
 
 func TestSubscriptionService_UpdateUsedSlots_UpdateError(t *testing.T) {
 	conf := config.CreateConfig()
+	conf.Server.SubscriptionOn = true
+	conf.Server.Environment = config.Development
 	userID := uuid.New()
 	repo := &fakeZonesRepo{
-		getByUserID: &models.ZonesSubscriptions{UserID: userID, TotalSlots: 5, UsedSlots: 1, Status: stripe.SubscriptionStatusActive},
-		updateErr:   errors.New("boom"),
+		getByUserErr: errors.New("boom"),
 	}
 	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{})
 
-	err := service.UpdateUsedSlots(userID, 1, true)
+	_, err := service.GetByUserID(userID)
 	assert.Error(t, err)
 }
 
@@ -366,15 +367,6 @@ func TestSubscriptionService_CancelSubscription_Validations(t *testing.T) {
 				Status:               stripe.SubscriptionStatusCanceled,
 			},
 			expectedErr: "subscription is not active",
-		},
-		{
-			name: "Error: Cannot cancel with used slots",
-			sub: &models.ZonesSubscriptions{
-				StripeSubscriptionID: "sub_123",
-				Status:               stripe.SubscriptionStatusActive,
-				UsedSlots:            1,
-			},
-			expectedErr: "cannot cancel subscription because 1 slots are currently in use",
 		},
 	}
 

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_service_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_service_test.go
@@ -970,3 +970,175 @@ func TestSubscriptionService_HandleWebhook_SubscriptionDeleted_NoEmail(t *testin
 	err := service.HandleWebhook(payload, sig)
 	assert.NoError(t, err)
 }
+
+func TestSubscriptionService_CalculateProratedAmount(t *testing.T) {
+	conf := config.CreateConfig()
+	conf.Stripe.StripeZonePrice = 10.0
+	conf.Stripe.StripeBillingAnchorDay = 15
+	conf.Stripe.StripeBillingTimezone = "UTC"
+	service := NewSubscriptionService(conf, &fakeZonesRepo{}, &fakeZonesEmailSender{}).(*zoneSubscriptionService)
+
+	amount := service.calculateProratedAmount(3)
+	assert.True(t, amount >= 0)
+}
+
+func TestSubscriptionService_CreateCheckoutSession_GetByUserIDError(t *testing.T) {
+	conf := config.CreateConfig()
+	// GetByUserID falla → sub = nil → ensureCustomer con nil → intenta crear customer en Stripe → falla
+	repo := &fakeZonesRepo{getByUserErr: errors.New("db error")}
+	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{})
+
+	_, err := service.CreateCheckoutSession(uuid.New(), "user@example.com", 2, "ok", "cancel")
+	assert.Error(t, err)
+}
+
+func TestSubscriptionService_EnsureCustomer_ExistingSubNoCustomerID(t *testing.T) {
+	conf := config.CreateConfig()
+	repo := &fakeZonesRepo{}
+	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{}).(*zoneSubscriptionService)
+
+	// existingSub != nil pero StripeCustomerID == "" → intenta crear customer en Stripe → falla por no tener key
+	existing := &models.ZonesSubscriptions{
+		UserID:     uuid.New(),
+		TotalSlots: 2,
+		Status:     "pending",
+	}
+	_, err := service.ensureCustomer(uuid.New(), "user@example.com", 2, existing)
+	assert.Error(t, err)
+}
+
+func TestSubscriptionService_ReactivateSubscription_NotFound(t *testing.T) {
+	conf := config.CreateConfig()
+	repo := &fakeZonesRepo{getByUserErr: errors.New("not found")}
+	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{})
+
+	_, err := service.ReactivateSubscription(uuid.New())
+	assert.Error(t, err)
+}
+
+func TestSubscriptionService_ReactivateSubscription_MissingStripeID(t *testing.T) {
+	conf := config.CreateConfig()
+	repo := &fakeZonesRepo{getByUserID: &models.ZonesSubscriptions{
+		Status: StatusPendingCancellation,
+	}}
+	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{})
+
+	_, err := service.ReactivateSubscription(uuid.New())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "subscription not found for user")
+}
+
+func TestSubscriptionService_ReactivateSubscription_NotPendingCancellation(t *testing.T) {
+	conf := config.CreateConfig()
+	repo := &fakeZonesRepo{getByUserID: &models.ZonesSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		Status:               stripe.SubscriptionStatusActive,
+	}}
+	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{})
+
+	_, err := service.ReactivateSubscription(uuid.New())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "subscription is not pending cancellation")
+}
+
+func TestSubscriptionService_StopAllJobs_UpdateError(t *testing.T) {
+	conf := config.CreateConfig()
+	repo := &fakeZonesRepo{updateErr: errors.New("db error")}
+	service := NewSubscriptionService(conf, repo, &fakeZonesEmailSender{}).(*zoneSubscriptionService)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	portStr := strings.TrimPrefix(server.URL, "http://127.0.0.1:")
+	port, _ := strconv.Atoi(portStr)
+	conf.Server.Port = port
+
+	sub := &models.ZonesSubscriptions{UserID: uuid.New(), UsedSlots: 1}
+	err := service.stopAllJobs(sub)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestSubscriptionService_HandleWebhook_InvoicePaymentFailed_NoSubscriptionID(t *testing.T) {
+	secret := "whsec_test_secret"
+	conf := webhookConf(secret)
+	service := NewSubscriptionService(conf, &fakeZonesRepo{}, &fakeZonesEmailSender{})
+
+	obj := map[string]interface{}{
+		"id":            "in_fail_nosub",
+		"object":        "invoice",
+		"amount_due":    1000,
+		"attempt_count": 1,
+		"parent": map[string]interface{}{
+			"subscription_details": map[string]interface{}{
+				"subscription": map[string]interface{}{
+					"id": "",
+				},
+			},
+		},
+	}
+	payload := buildStripeEventPayload("invoice.payment_failed", obj)
+	sig := generateStripeSignature(secret, payload)
+
+	err := service.HandleWebhook(payload, sig)
+	assert.NoError(t, err) // skips gracefully
+}
+
+func TestSubscriptionService_HandleWebhook_InvoicePaymentFailed_NoEmail(t *testing.T) {
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"sub_fail_123", "status":"canceled"}`))
+	}))
+	defer stripeServer.Close()
+
+	originalBackend := stripe.GetBackend(stripe.APIBackend)
+	defer stripe.SetBackend(stripe.APIBackend, originalBackend)
+	stripe.SetBackend(stripe.APIBackend, stripe.GetBackendWithConfig(stripe.APIBackend, &stripe.BackendConfig{
+		URL: stripe.String(stripeServer.URL),
+	}))
+	stripe.Key = "sk_test_dummy"
+
+	internalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internalServer.Close()
+
+	secret := "whsec_test_secret"
+	conf := webhookConf(secret)
+	portStr := strings.TrimPrefix(internalServer.URL, "http://127.0.0.1:")
+	port, _ := strconv.Atoi(portStr)
+	conf.Server.Port = port
+
+	emailSender := &fakeZonesEmailSender{}
+	repo := &fakeZonesRepo{
+		getByStripeSubID: &models.ZonesSubscriptions{
+			UserID:               uuid.New(),
+			TotalSlots:           5,
+			StripeSubscriptionID: "sub_fail_noemail",
+		},
+	}
+	service := NewSubscriptionService(conf, repo, emailSender)
+
+	obj := map[string]interface{}{
+		"id":             "in_fail_noemail",
+		"object":         "invoice",
+		"customer_email": "",
+		"amount_due":     1500,
+		"attempt_count":  1,
+		"parent": map[string]interface{}{
+			"subscription_details": map[string]interface{}{
+				"subscription": map[string]interface{}{
+					"id": "sub_fail_noemail",
+				},
+			},
+		},
+	}
+	payload := buildStripeEventPayload("invoice.payment_failed", obj)
+	sig := generateStripeSignature(secret, payload)
+
+	err := service.HandleWebhook(payload, sig)
+	assert.NoError(t, err)
+	assert.False(t, emailSender.sendRejectedCalled)
+}

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
@@ -175,7 +175,7 @@ func TestGetNextInvoiceAmount_PendingOrCanceled(t *testing.T) {
 
 	amount, err := testSvc.getNextInvoiceAmount(sub)
 	assert.NoError(t, err)
-	assert.True(t, amount.Equal(decimal.NewFromFloat(testConf.Stripe.StripeZonePrice*4)))
+	assert.True(t, amount.Equal(decimal.Zero))
 
 	updated, _ := testRepo.GetByUserID(userID)
 	updated.Status = stripe.SubscriptionStatusCanceled
@@ -183,7 +183,7 @@ func TestGetNextInvoiceAmount_PendingOrCanceled(t *testing.T) {
 
 	amount, err = testSvc.getNextInvoiceAmount(sub)
 	assert.NoError(t, err)
-	assert.True(t, amount.Equal(decimal.NewFromFloat(testConf.Stripe.StripeZonePrice*4)))
+	assert.True(t, amount.Equal(decimal.Zero))
 }
 
 func TestStopAllJobs_ResetsSlots(t *testing.T) {

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
@@ -163,15 +163,17 @@ func TestGetNextInvoiceAmount_PendingOrCanceled(t *testing.T) {
 	clearZonesTables()
 	userID := uuid.New()
 
-	createZoneSubscription(t, &models.ZonesSubscriptions{
+	sub := &models.ZonesSubscriptions{
 		UserID:           userID,
 		StripeCustomerID: "cust_pending",
 		TotalSlots:       4,
 		AmountDue:        decimal.Zero,
 		Status:           "pending",
-	})
+	}
 
-	amount, err := testSvc.getNextInvoiceAmount(userID)
+	createZoneSubscription(t, sub)
+
+	amount, err := testSvc.getNextInvoiceAmount(sub)
 	assert.NoError(t, err)
 	assert.True(t, amount.Equal(decimal.NewFromFloat(testConf.Stripe.StripeZonePrice*4)))
 
@@ -179,7 +181,7 @@ func TestGetNextInvoiceAmount_PendingOrCanceled(t *testing.T) {
 	updated.Status = stripe.SubscriptionStatusCanceled
 	_, _ = testRepo.Update(updated)
 
-	amount, err = testSvc.getNextInvoiceAmount(userID)
+	amount, err = testSvc.getNextInvoiceAmount(sub)
 	assert.NoError(t, err)
 	assert.True(t, amount.Equal(decimal.NewFromFloat(testConf.Stripe.StripeZonePrice*4)))
 }

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3312,6 +3312,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/subscriptions/reactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reactivates the user's cancelled subscription.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Reactivate subscription",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/subscriptions/slots": {
             "put": {
                 "security": [

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3305,6 +3305,49 @@
                 }
             }
         },
+        "/subscriptions/reactivate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reactivates the user's cancelled subscription.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Reactivate subscription",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/subscriptions/slots": {
             "put": {
                 "security": [

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -2819,6 +2819,33 @@ paths:
       summary: Get price metrics and dates
       tags:
       - payment-service-subscriptions
+  /subscriptions/reactivate:
+    post:
+      description: Reactivates the user's cancelled subscription.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dtos.SubscriptionStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Reactivate subscription
+      tags:
+      - payment-service-subscriptions
   /subscriptions/slots:
     put:
       consumes:


### PR DESCRIPTION
## Changes:

* Added `GET /subscriptions/status` endpoint returning the user's current subscription
* Added `GetStatus` service method that fetches the subscription, refreshes `AmountDue` from Stripe, and returns the updated record
* Added `UpdateSlots` guard to reject updates when the subscription is not active
* Added `CancelSubscription` guard to reject cancellation when `UsedSlots > 0`
* Updated `CheckAvalibility` to return `false` when the subscription is not active
* Fixed `getNextInvoiceAmount` to fall back to the configured price when the subscription is pending or cancelled rather than calling Stripe
* Updated `ensureCustomer` to persist a new `ZonesSubscriptions` row on Stripe customer creation
* Added `PUT /subscriptions/slots` to Swagger docs
* Extended `zones_subscriptions_service_test.go` with additional webhook and validation test cases