### PR TITLE
US-113: Admin add mock subscriptions

### DIFF
--- a/internal/payment-service/controllers/zones-subscriptions/controller.go
+++ b/internal/payment-service/controllers/zones-subscriptions/controller.go
@@ -11,5 +11,9 @@ type ZonesSubscriptionsController interface {
 	GetPricingInfo(c *gin.Context)
 	CheckInternalAvailability(c *gin.Context)
 	InternalUpdateUsedSlots(c *gin.Context)
+	AdminListSubscriptions(c *gin.Context)
+	AdminCreateSubscription(c *gin.Context)
+	AdminUpdateSlots(c *gin.Context)
+	AdminCancelSubscription(c *gin.Context)
 	HandleWebhook(c *gin.Context)
 }

--- a/internal/payment-service/controllers/zones-subscriptions/zones_subscriptions.go
+++ b/internal/payment-service/controllers/zones-subscriptions/zones_subscriptions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/FeedTheRealm-org/core-service/config"
 	"github.com/FeedTheRealm-org/core-service/internal/common_handlers"
@@ -298,6 +299,200 @@ func (zc *subscriptionController) InternalUpdateUsedSlots(c *gin.Context) {
 	}
 
 	common_handlers.HandleSuccessResponse(c, 200, gin.H{"status": "ok"})
+}
+
+// AdminListSubscriptions godoc
+// @Summary      Admin list all subscriptions
+// @Description  Returns a paginated list of every subscription (comp and Stripe alike), admin only.
+// @Tags         payment-service-subscriptions
+// @Security     BearerAuth
+// @Produce      json
+// @Param        offset  query     int  false  "Pagination offset" default(0)
+// @Param        limit   query     int  false  "Pagination limit"  default(50)
+// @Success      200     {object}  dtos.AdminSubscriptionsListResponse
+// @Failure      400     {object}  dtos.ErrorResponse
+// @Failure      401     {object}  dtos.ErrorResponse
+// @Failure      500     {object}  dtos.ErrorResponse
+// @Router       /subscriptions/admin/users [get]
+func (zc *subscriptionController) AdminListSubscriptions(c *gin.Context) {
+	offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if err != nil || offset < 0 {
+		_ = c.Error(custom_errors.NewBadRequestError("invalid offset"))
+		return
+	}
+
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	if err != nil || limit <= 0 {
+		_ = c.Error(custom_errors.NewBadRequestError("invalid limit"))
+		return
+	}
+
+	subs, total, err := zc.zonesSubscriptionsService.GetAllSubscriptions(offset, limit)
+	if err != nil {
+		logger.Logger.Error("Failed to list subscriptions: " + err.Error())
+		_ = c.Error(custom_errors.NewInternalServerError("Failed to list subscriptions: " + err.Error()))
+		return
+	}
+
+	items := make([]dtos.AdminSubscriptionResponse, 0, len(subs))
+	for _, sub := range subs {
+		amountDue, _ := sub.AmountDue.Float64()
+		items = append(items, dtos.AdminSubscriptionResponse{
+			UserID:          sub.UserID.String(),
+			Slots:           sub.TotalSlots,
+			UsedSlots:       sub.UsedSlots,
+			Status:          string(sub.Status),
+			NextBillingDate: sub.NextBillingDate,
+			AmountDue:       amountDue,
+			IsAdminGranted:  sub.IsAdminGranted,
+		})
+	}
+
+	common_handlers.HandleSuccessResponse(c, 200, &dtos.AdminSubscriptionsListResponse{
+		Subscriptions: items,
+		TotalCount:    total,
+	})
+}
+
+// AdminCreateSubscription godoc
+// @Summary      Admin grant comp subscription
+// @Description  Grants a free/comp subscription to a user, bypassing Stripe.
+// @Tags         payment-service-subscriptions
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        user_id  path      string                             true  "User ID"
+// @Param        request  body      dtos.AdminCreateSubscriptionRequest  true  "Admin create subscription payload"
+// @Success      200      {object}  dtos.SubscriptionStatusResponse
+// @Failure      400      {object}  dtos.ErrorResponse
+// @Failure      401      {object}  dtos.ErrorResponse
+// @Failure      500      {object}  dtos.ErrorResponse
+// @Router       /subscriptions/admin/users/{user_id} [post]
+func (zc *subscriptionController) AdminCreateSubscription(c *gin.Context) {
+	userIdStr := c.Param("user_id")
+	userID, err := uuid.Parse(userIdStr)
+	if err != nil {
+		logger.Logger.Error("Failed to parse user_id from param: " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Invalid user_id in path"))
+		return
+	}
+
+	var req dtos.AdminCreateSubscriptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(custom_errors.NewBadRequestError("invalid request body: " + err.Error()))
+		return
+	}
+
+	sub, err := zc.zonesSubscriptionsService.AdminCreateSubscription(userID, req.Email, req.Slots)
+	if err != nil {
+		logger.Logger.Error("Failed to admin-create subscription for user " + userID.String() + ": " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Failed to create subscription: " + err.Error()))
+		return
+	}
+
+	amountDue, _ := sub.AmountDue.Float64()
+
+	res := &dtos.SubscriptionStatusResponse{
+		Slots:           sub.TotalSlots,
+		UsedSlots:       sub.UsedSlots,
+		Status:          string(sub.Status),
+		NextBillingDate: sub.NextBillingDate,
+		AmountDue:       amountDue,
+	}
+	common_handlers.HandleSuccessResponse(c, 200, res)
+}
+
+// AdminUpdateSlots godoc
+// @Summary      Admin update subscription slots
+// @Description  Updates the total slots of a user's subscription, bypassing normal user-flow restrictions (e.g. allowed even if pending cancellation).
+// @Tags         payment-service-subscriptions
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        user_id  path      string                           true  "User ID"
+// @Param        request  body      dtos.UpdateSubscriptionRequest  true  "Update subscription slots payload"
+// @Success      200      {object}  dtos.SubscriptionStatusResponse
+// @Failure      400      {object}  dtos.ErrorResponse
+// @Failure      401      {object}  dtos.ErrorResponse
+// @Failure      500      {object}  dtos.ErrorResponse
+// @Router       /subscriptions/admin/users/{user_id}/slots [put]
+func (zc *subscriptionController) AdminUpdateSlots(c *gin.Context) {
+	userIdStr := c.Param("user_id")
+	userID, err := uuid.Parse(userIdStr)
+	if err != nil {
+		logger.Logger.Error("Failed to parse user_id from param: " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Invalid user_id in path"))
+		return
+	}
+
+	var req dtos.UpdateSubscriptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(custom_errors.NewBadRequestError("invalid request body: " + err.Error()))
+		return
+	}
+
+	sub, err := zc.zonesSubscriptionsService.AdminUpdateSlots(userID, req.Slots)
+	if err != nil {
+		if _, ok := err.(*zones_subscriptions.CannotExceedTotalSlotsError); ok {
+			logger.Logger.Warnf("Admin attempted to reduce slots to %d for user %s, but user is currently using more slots than that", req.Slots, userID.String())
+			_ = c.Error(custom_errors.NewBadRequestError(fmt.Sprintf("cannot reduce slots to %d because the user is currently using more than that", req.Slots)))
+			return
+		}
+		logger.Logger.Error("Failed to admin-update subscription slots for user " + userID.String() + ": " + err.Error())
+		_ = c.Error(custom_errors.NewInternalServerError("Failed to update subscription slots: " + err.Error()))
+		return
+	}
+
+	amountDue, _ := sub.AmountDue.Float64()
+
+	res := &dtos.SubscriptionStatusResponse{
+		Slots:           sub.TotalSlots,
+		UsedSlots:       sub.UsedSlots,
+		Status:          string(sub.Status),
+		NextBillingDate: sub.NextBillingDate,
+		AmountDue:       amountDue,
+	}
+	common_handlers.HandleSuccessResponse(c, 200, res)
+}
+
+// AdminCancelSubscription godoc
+// @Summary      Admin cancel subscription
+// @Description  Cancels a user's subscription
+// @Tags         payment-service-subscriptions
+// @Security     BearerAuth
+// @Produce      json
+// @Param        user_id  path      string  true  "User ID"
+// @Success      200      {object}  dtos.SubscriptionStatusResponse
+// @Failure      400      {object}  dtos.ErrorResponse
+// @Failure      401      {object}  dtos.ErrorResponse
+// @Failure      500      {object}  dtos.ErrorResponse
+// @Router       /subscriptions/admin/users/{user_id} [delete]
+func (zc *subscriptionController) AdminCancelSubscription(c *gin.Context) {
+	userIdStr := c.Param("user_id")
+	userID, err := uuid.Parse(userIdStr)
+	if err != nil {
+		logger.Logger.Error("Failed to parse user_id from param: " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Invalid user_id in path"))
+		return
+	}
+
+	sub, err := zc.zonesSubscriptionsService.AdminCancelSubscription(userID)
+	if err != nil {
+		logger.Logger.Error("Failed to admin-cancel subscription for user " + userID.String() + ": " + err.Error())
+		_ = c.Error(custom_errors.NewBadRequestError("Failed to cancel subscription: " + err.Error()))
+		return
+	}
+
+	amountDue, _ := sub.AmountDue.Float64()
+
+	res := &dtos.SubscriptionStatusResponse{
+		Slots:           sub.TotalSlots,
+		UsedSlots:       sub.UsedSlots,
+		Status:          string(sub.Status),
+		NextBillingDate: sub.NextBillingDate,
+		AmountDue:       amountDue,
+	}
+	common_handlers.HandleSuccessResponse(c, 200, res)
 }
 
 // HandleWebhook godoc

--- a/internal/payment-service/dtos/zones_subscriptions_dtos.go
+++ b/internal/payment-service/dtos/zones_subscriptions_dtos.go
@@ -19,6 +19,26 @@ type UpdateSubscriptionRequest struct {
 	Slots int `json:"slots" validate:"required"`
 }
 
+type AdminSubscriptionResponse struct {
+	UserID          string    `json:"user_id"`
+	Slots           int       `json:"slots"`
+	UsedSlots       int       `json:"used_slots"`
+	Status          string    `json:"status"`
+	NextBillingDate time.Time `json:"next_billing_date"`
+	AmountDue       float64   `json:"amount_due"`
+	IsAdminGranted  bool      `json:"is_admin_granted"`
+}
+
+type AdminSubscriptionsListResponse struct {
+	Subscriptions []AdminSubscriptionResponse `json:"subscriptions"`
+	TotalCount    int64                       `json:"total_count"`
+}
+
+type AdminCreateSubscriptionRequest struct {
+	Email string `json:"email" binding:"required,email"`
+	Slots int    `json:"slots" binding:"required,gt=0"`
+}
+
 type SubscriptionStatusResponse struct {
 	Slots           int       `json:"slots"`
 	UsedSlots       int       `json:"used_slots"`

--- a/internal/payment-service/models/zones_subscriptions.go
+++ b/internal/payment-service/models/zones_subscriptions.go
@@ -20,6 +20,7 @@ type ZonesSubscriptions struct {
 	NextBillingDate      time.Time                 `json:"next_billing_date"`
 	CreatedAt            time.Time                 `json:"created_at"`
 	UpdatedAt            time.Time                 `json:"updated_at"`
+	IsAdminGranted       bool                      `json:"is_admin_granted" gorm:"default:false"`
 }
 
 func (ZonesSubscriptions) TableName() string {

--- a/internal/payment-service/repositories/zones-subscriptions/repository.go
+++ b/internal/payment-service/repositories/zones-subscriptions/repository.go
@@ -8,6 +8,7 @@ import (
 type ZonesSubscriptionsRepository interface {
 	Create(subscription *models.ZonesSubscriptions) (*models.ZonesSubscriptions, error)
 	Update(subscription *models.ZonesSubscriptions) (*models.ZonesSubscriptions, error)
+	GetAll(offset, limit int) ([]*models.ZonesSubscriptions, int64, error)
 	GetByUserID(userID uuid.UUID) (*models.ZonesSubscriptions, error)
 	GetByStripeCustomerID(customerID string) (*models.ZonesSubscriptions, error)
 	GetByStripeSubscriptionID(subID string) (*models.ZonesSubscriptions, error)

--- a/internal/payment-service/repositories/zones-subscriptions/zones_subscriptions.go
+++ b/internal/payment-service/repositories/zones-subscriptions/zones_subscriptions.go
@@ -31,6 +31,26 @@ func (zsr *zonesSubscriptionsRepository) Update(subscription *models.ZonesSubscr
 	return subscription, err
 }
 
+func (zsr *zonesSubscriptionsRepository) GetAll(offset, limit int) ([]*models.ZonesSubscriptions, int64, error) {
+	var subs []*models.ZonesSubscriptions
+	var total int64
+
+	if err := zsr.db.Conn.Model(&models.ZonesSubscriptions{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	err := zsr.db.Conn.
+		Order("created_at asc").
+		Offset(offset).
+		Limit(limit).
+		Find(&subs).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return subs, total, nil
+}
+
 func (zsr *zonesSubscriptionsRepository) GetByUserID(userID uuid.UUID) (*models.ZonesSubscriptions, error) {
 	var sub models.ZonesSubscriptions
 	err := zsr.db.Conn.Where("user_id = ?", userID).First(&sub).Error

--- a/internal/payment-service/repositories/zones-subscriptions/zones_subscriptions_test.go
+++ b/internal/payment-service/repositories/zones-subscriptions/zones_subscriptions_test.go
@@ -1,8 +1,10 @@
 package zones_subscriptions
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/FeedTheRealm-org/core-service/config"
 	"github.com/FeedTheRealm-org/core-service/internal/payment-service/models"
@@ -71,4 +73,72 @@ func TestZonesSubscriptionsRepository_CreateGetUpdate(t *testing.T) {
 	updated, err := zonesRepo.Update(byUser)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, updated.UsedSlots)
+}
+
+func TestZonesSubscriptionsRepository_GetAll(t *testing.T) {
+	clearZonesTables()
+
+	const total = 5
+	created := make([]*models.ZonesSubscriptions, 0, total)
+
+	for i := 0; i < total; i++ {
+		sub := &models.ZonesSubscriptions{
+			UserID:               uuid.New(),
+			StripeCustomerID:     fmt.Sprintf("cust_%d", i),
+			StripeSubscriptionID: fmt.Sprintf("sub_%d", i),
+			TotalSlots:           5,
+			UsedSlots:            0,
+			AmountDue:            decimal.NewFromFloat(1.0),
+			Status:               stripe.SubscriptionStatusActive,
+		}
+		c, err := zonesRepo.Create(sub)
+		assert.NoError(t, err)
+		created = append(created, c)
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Run("returns all when limit covers total", func(t *testing.T) {
+		subs, count, err := zonesRepo.GetAll(0, total)
+		assert.NoError(t, err)
+		assert.EqualValues(t, total, count)
+		assert.Len(t, subs, total)
+
+		for i := 0; i < len(subs)-1; i++ {
+			assert.True(t, subs[i].CreatedAt.Before(subs[i+1].CreatedAt) || subs[i].CreatedAt.Equal(subs[i+1].CreatedAt))
+		}
+		assert.Equal(t, created[0].StripeSubscriptionID, subs[0].StripeSubscriptionID)
+	})
+
+	t.Run("respects limit", func(t *testing.T) {
+		subs, count, err := zonesRepo.GetAll(0, 2)
+		assert.NoError(t, err)
+		assert.EqualValues(t, total, count)
+		assert.Len(t, subs, 2)
+		assert.Equal(t, created[0].StripeSubscriptionID, subs[0].StripeSubscriptionID)
+		assert.Equal(t, created[1].StripeSubscriptionID, subs[1].StripeSubscriptionID)
+	})
+
+	t.Run("respects offset", func(t *testing.T) {
+		subs, count, err := zonesRepo.GetAll(2, 2)
+		assert.NoError(t, err)
+		assert.EqualValues(t, total, count)
+		assert.Len(t, subs, 2)
+		assert.Equal(t, created[2].StripeSubscriptionID, subs[0].StripeSubscriptionID)
+		assert.Equal(t, created[3].StripeSubscriptionID, subs[1].StripeSubscriptionID)
+	})
+
+	t.Run("offset beyond total returns empty slice", func(t *testing.T) {
+		subs, count, err := zonesRepo.GetAll(total+10, 10)
+		assert.NoError(t, err)
+		assert.EqualValues(t, total, count)
+		assert.Empty(t, subs)
+	})
+
+	t.Run("empty table returns zero total and empty slice", func(t *testing.T) {
+		clearZonesTables()
+		subs, count, err := zonesRepo.GetAll(0, 10)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 0, count)
+		assert.Empty(t, subs)
+	})
 }

--- a/internal/payment-service/router/router.go
+++ b/internal/payment-service/router/router.go
@@ -81,6 +81,12 @@ func SetupSubscriptionsServiceRouter(conf *config.Config, db *config.DB, subscri
 	// Webhook for Subscriptions
 	subscriptionGroup.POST("/webhook/stripe", zonesSubscriptionsController.HandleWebhook)
 
+	// Admin routes for subscription management
+	subscriptionGroup.GET("/admin/users", middleware.AdminCheckMiddleware(), zonesSubscriptionsController.AdminListSubscriptions)
+	subscriptionGroup.POST("/admin/users/:user_id", middleware.AdminCheckMiddleware(), zonesSubscriptionsController.AdminCreateSubscription)
+	subscriptionGroup.DELETE("/admin/users/:user_id", middleware.AdminCheckMiddleware(), zonesSubscriptionsController.AdminCancelSubscription)
+	subscriptionGroup.PUT("/admin/users/:user_id/slots", middleware.AdminCheckMiddleware(), zonesSubscriptionsController.AdminUpdateSlots)
+
 	// Internal routes bypassed by JWT
 	internalGroup := subscriptionGroup.Group("/internal")
 	internalGroup.GET("/users/:user_id/status", zonesSubscriptionsController.CheckInternalAvailability)

--- a/internal/payment-service/services/zones-subscriptions/service.go
+++ b/internal/payment-service/services/zones-subscriptions/service.go
@@ -10,11 +10,15 @@ import (
 type SubscriptionService interface {
 	UpdateSlots(userID uuid.UUID, newSlots int) (*models.ZonesSubscriptions, error)
 	UpdateUsedSlots(userID uuid.UUID, slots int, areUsed bool) error
+	GetAllSubscriptions(offset, limit int) ([]*models.ZonesSubscriptions, int64, error)
 	GetByUserID(userID uuid.UUID) (*models.ZonesSubscriptions, error)
 	GetPricingInfo() (float64, time.Time)
 	CheckAvalibility(userID uuid.UUID) (bool, int, error)
 	CreateCheckoutSession(userID uuid.UUID, email string, slots int, successUrl string, cancelUrl string) (string, error)
 	CancelSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error)
 	ReactivateSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error)
+	AdminCreateSubscription(userID uuid.UUID, email string, slots int) (*models.ZonesSubscriptions, error)
+	AdminUpdateSlots(userID uuid.UUID, newSlots int) (*models.ZonesSubscriptions, error)
+	AdminCancelSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error)
 	HandleWebhook(payload []byte, signature string) error
 }

--- a/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
+++ b/internal/payment-service/services/zones-subscriptions/zones-subscriptions.go
@@ -220,6 +220,23 @@ func (zs *zoneSubscriptionService) UpdateUsedSlots(userID uuid.UUID, slots int, 
 	return nil
 }
 
+func (zs *zoneSubscriptionService) GetAllSubscriptions(offset, limit int) ([]*models.ZonesSubscriptions, int64, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	subs, total, err := zs.repo.GetAll(offset, limit)
+	if err != nil {
+		logger.Logger.Errorf("Failed to list subscriptions (offset=%d, limit=%d): %v", offset, limit, err)
+		return nil, 0, err
+	}
+
+	return subs, total, nil
+}
+
 func (zs *zoneSubscriptionService) GetByUserID(userID uuid.UUID) (*models.ZonesSubscriptions, error) {
 	if !zs.conf.Server.SubscriptionOn && zs.conf.Server.Environment != config.Production {
 		logger.Logger.Infof("Subscription system is turned off, returning default subscription for user %s", userID)
@@ -359,6 +376,140 @@ func (zs *zoneSubscriptionService) stopAllJobs(sub *models.ZonesSubscriptions) e
 	}
 
 	return nil
+}
+
+func (zs *zoneSubscriptionService) AdminCreateSubscription(userID uuid.UUID, email string, slots int) (*models.ZonesSubscriptions, error) {
+	logger.Logger.Infof("Admin granting comp subscription to user %s (%d slots)", userID, slots)
+
+	if slots <= 0 {
+		return nil, fmt.Errorf("slots must be greater than 0")
+	}
+
+	existing, err := zs.repo.GetByUserID(userID)
+	if err == nil && existing != nil {
+		if existing.Status == stripe.SubscriptionStatusActive || existing.Status == StatusPendingCancellation {
+			return nil, fmt.Errorf("user %s already has an active subscription", userID)
+		}
+
+		existing.StripeCustomerID = ""
+		existing.StripeSubscriptionID = ""
+		existing.TotalSlots = slots
+		existing.UsedSlots = 0
+		existing.AmountDue = decimal.Zero
+		existing.Status = stripe.SubscriptionStatusActive
+		existing.IsAdminGranted = true
+		existing.NextBillingDate = time.Time{}
+
+		updated, err := zs.repo.Update(existing)
+		if err != nil {
+			logger.Logger.Errorf("Failed to update comp subscription for user %s: %v", userID, err)
+			return nil, err
+		}
+
+		logger.Logger.Infof("Admin comp subscription (re-used record) active for user %s", userID)
+		return updated, nil
+	}
+
+	sub := &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "",
+		TotalSlots:       slots,
+		UsedSlots:        0,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusActive,
+		IsAdminGranted:   true,
+		NextBillingDate:  time.Time{},
+	}
+
+	created, err := zs.repo.Create(sub)
+	if err != nil {
+		logger.Logger.Errorf("Failed to create comp subscription for user %s: %v", userID, err)
+		return nil, err
+	}
+
+	logger.Logger.Infof("Admin comp subscription created for user %s", userID)
+	return created, nil
+}
+
+func (zs *zoneSubscriptionService) AdminUpdateSlots(userID uuid.UUID, newSlots int) (*models.ZonesSubscriptions, error) {
+	logger.Logger.Infof("Admin updating subscription slots for user %s to %d", userID, newSlots)
+
+	if newSlots <= 0 {
+		return nil, fmt.Errorf("slots must be greater than 0")
+	}
+
+	sub, err := zs.repo.GetByUserID(userID)
+	if err != nil {
+		logger.Logger.Errorf("Subscription not found for user %s: %v", userID, err)
+		return nil, err
+	}
+
+	if sub.Status != stripe.SubscriptionStatusActive && sub.Status != StatusPendingCancellation {
+		return nil, fmt.Errorf("subscription is not active")
+	}
+
+	if newSlots < sub.UsedSlots {
+		return nil, &CannotExceedTotalSlotsError{}
+	}
+
+	if !sub.IsAdminGranted {
+		return nil, fmt.Errorf("cannot update slots for non-admin granted subscription")
+	}
+
+	sub.TotalSlots = newSlots
+
+	updated, err := zs.repo.Update(sub)
+	if err != nil {
+		logger.Logger.Errorf("Failed to update comp subscription slots for user %s: %v", userID, err)
+		return nil, err
+	}
+
+	logger.Logger.Infof("Admin comp subscription slots updated to %d for user %s", newSlots, userID)
+	return updated, nil
+}
+
+func (zs *zoneSubscriptionService) AdminCancelSubscription(userID uuid.UUID) (*models.ZonesSubscriptions, error) {
+	logger.Logger.Infof("Admin cancelling subscription for user %s", userID)
+
+	sub, err := zs.repo.GetByUserID(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if sub.Status != stripe.SubscriptionStatusActive && sub.Status != StatusPendingCancellation {
+		return nil, fmt.Errorf("subscription is not active")
+	}
+
+	if err := zs.stopAllJobs(sub); err != nil {
+		logger.Logger.Errorf("Failed to run stopAllJobs for user %s: %v", userID, err)
+		return nil, err
+	}
+
+	if !sub.IsAdminGranted {
+		updated, err := zs.CancelSubscription(userID)
+		if err != nil {
+			logger.Logger.Errorf("Failed to schedule cancellation for user %s: %v", userID, err)
+			return nil, err
+		}
+		return updated, nil
+	}
+
+	sub.Status = stripe.SubscriptionStatusCanceled
+	sub.IsAdminGranted = false
+	sub.TotalSlots = 0
+	sub.UsedSlots = 0
+	sub.AmountDue = decimal.Zero
+	sub.StripeCustomerID = ""
+	sub.StripeSubscriptionID = ""
+
+	updated, err := zs.repo.Update(sub)
+	if err != nil {
+		logger.Logger.Errorf("Failed to cancel comp subscription for user %s: %v", userID, err)
+		return nil, err
+	}
+
+	logger.Logger.Infof("Admin comp subscription cancelled immediately for user %s", userID)
+	return updated, nil
 }
 
 func (zs *zoneSubscriptionService) HandleWebhook(payload []byte, signature string) error {

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_service_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_service_test.go
@@ -49,6 +49,10 @@ func (f *fakeZonesRepo) Update(subscription *models.ZonesSubscriptions) (*models
 	return subscription, nil
 }
 
+func (f *fakeZonesRepo) GetAll(offset, limit int) ([]*models.ZonesSubscriptions, int64, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
 func (f *fakeZonesRepo) GetByUserID(userID uuid.UUID) (*models.ZonesSubscriptions, error) {
 	if f.getByUserErr != nil {
 		return nil, f.getByUserErr

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
@@ -239,3 +239,322 @@ func TestNextBillingDate_AnchorInFuture(t *testing.T) {
 	next := testSvc.nextBillingDate()
 	assert.True(t, next.After(time.Now().UTC()))
 }
+
+func TestAdminCreateSubscription_InvalidSlots(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	sub, err := testSvc.AdminCreateSubscription(userID, "user@example.com", 0)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "slots must be greater than 0")
+}
+
+func TestAdminCreateSubscription_NewUser(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	sub, err := testSvc.AdminCreateSubscription(userID, "user@example.com", 7)
+	assert.NoError(t, err)
+	assert.NotNil(t, sub)
+	assert.Equal(t, userID, sub.UserID)
+	assert.Equal(t, 7, sub.TotalSlots)
+	assert.Equal(t, 0, sub.UsedSlots)
+	assert.True(t, sub.IsAdminGranted)
+	assert.Equal(t, stripe.SubscriptionStatusActive, sub.Status)
+	assert.True(t, sub.AmountDue.Equal(decimal.Zero))
+	assert.Empty(t, sub.StripeCustomerID)
+}
+
+func TestAdminCreateSubscription_AlreadyActive(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_active",
+		TotalSlots:       3,
+		UsedSlots:        1,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusActive,
+	})
+
+	sub, err := testSvc.AdminCreateSubscription(userID, "user@example.com", 5)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "already has an active subscription")
+}
+
+func TestAdminCreateSubscription_AlreadyPendingCancellation(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_pending_cancel",
+		TotalSlots:       3,
+		UsedSlots:        1,
+		AmountDue:        decimal.Zero,
+		Status:           StatusPendingCancellation,
+	})
+
+	sub, err := testSvc.AdminCreateSubscription(userID, "user@example.com", 5)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "already has an active subscription")
+}
+
+func TestAdminCreateSubscription_ReusesInactiveRecord(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:               userID,
+		StripeCustomerID:     "cust_old",
+		StripeSubscriptionID: "sub_old",
+		TotalSlots:           3,
+		UsedSlots:            1,
+		AmountDue:            decimal.NewFromFloat(2.5),
+		Status:               stripe.SubscriptionStatusCanceled,
+	})
+
+	sub, err := testSvc.AdminCreateSubscription(userID, "user@example.com", 10)
+	assert.NoError(t, err)
+	assert.NotNil(t, sub)
+	assert.Equal(t, 10, sub.TotalSlots)
+	assert.Equal(t, 0, sub.UsedSlots)
+	assert.True(t, sub.IsAdminGranted)
+	assert.Empty(t, sub.StripeCustomerID)
+	assert.Empty(t, sub.StripeSubscriptionID)
+	assert.Equal(t, stripe.SubscriptionStatusActive, sub.Status)
+	assert.True(t, sub.AmountDue.Equal(decimal.Zero))
+
+	persisted, err := testRepo.GetByUserID(userID)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, persisted.TotalSlots)
+}
+
+func TestAdminUpdateSlots_InvalidSlots(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	sub, err := testSvc.AdminUpdateSlots(userID, 0)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "slots must be greater than 0")
+}
+
+func TestAdminUpdateSlots_NotFound(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	sub, err := testSvc.AdminUpdateSlots(userID, 5)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+}
+
+func TestAdminUpdateSlots_NotActive(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_inactive",
+		TotalSlots:       5,
+		UsedSlots:        1,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusCanceled,
+		IsAdminGranted:   true,
+	})
+
+	sub, err := testSvc.AdminUpdateSlots(userID, 8)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "subscription is not active")
+}
+
+func TestAdminUpdateSlots_BelowUsedSlots(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_below",
+		TotalSlots:       5,
+		UsedSlots:        4,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusActive,
+		IsAdminGranted:   true,
+	})
+
+	sub, err := testSvc.AdminUpdateSlots(userID, 2)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	_, isCannotExceed := err.(*CannotExceedTotalSlotsError)
+	assert.True(t, isCannotExceed)
+}
+
+func TestAdminUpdateSlots_NotAdminGranted(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_notadmin",
+		TotalSlots:       5,
+		UsedSlots:        1,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusActive,
+		IsAdminGranted:   false,
+	})
+
+	sub, err := testSvc.AdminUpdateSlots(userID, 8)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "cannot update slots for non-admin granted subscription")
+}
+
+func TestAdminUpdateSlots_Success(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_success",
+		TotalSlots:       5,
+		UsedSlots:        2,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusActive,
+		IsAdminGranted:   true,
+	})
+
+	sub, err := testSvc.AdminUpdateSlots(userID, 12)
+	assert.NoError(t, err)
+	assert.NotNil(t, sub)
+	assert.Equal(t, 12, sub.TotalSlots)
+
+	persisted, _ := testRepo.GetByUserID(userID)
+	assert.Equal(t, 12, persisted.TotalSlots)
+}
+
+func TestAdminCancelSubscription_NotFound(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	sub, err := testSvc.AdminCancelSubscription(userID)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+}
+
+func TestAdminCancelSubscription_NotActive(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_notactive_cancel",
+		TotalSlots:       5,
+		UsedSlots:        1,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusCanceled,
+		IsAdminGranted:   true,
+	})
+
+	sub, err := testSvc.AdminCancelSubscription(userID)
+	assert.Error(t, err)
+	assert.Nil(t, sub)
+	assert.Contains(t, err.Error(), "subscription is not active")
+}
+
+func TestAdminCancelSubscription_AdminGranted_Immediate(t *testing.T) {
+	clearZonesTables()
+	userID := uuid.New()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           userID,
+		StripeCustomerID: "cust_admin_cancel",
+		TotalSlots:       5,
+		UsedSlots:        2,
+		AmountDue:        decimal.NewFromFloat(3.0),
+		Status:           stripe.SubscriptionStatusActive,
+		IsAdminGranted:   true,
+	})
+
+	sub, err := testSvc.AdminCancelSubscription(userID)
+	assert.NoError(t, err)
+	assert.NotNil(t, sub)
+	assert.Equal(t, stripe.SubscriptionStatusCanceled, sub.Status)
+	assert.False(t, sub.IsAdminGranted)
+	assert.Equal(t, 0, sub.TotalSlots)
+	assert.Equal(t, 0, sub.UsedSlots)
+	assert.True(t, sub.AmountDue.Equal(decimal.Zero))
+	assert.Empty(t, sub.StripeCustomerID)
+	assert.Empty(t, sub.StripeSubscriptionID)
+}
+
+func TestGetAllSubscriptions_Passthrough(t *testing.T) {
+	clearZonesTables()
+
+	for i := 0; i < 3; i++ {
+		createZoneSubscription(t, &models.ZonesSubscriptions{
+			UserID:           uuid.New(),
+			StripeCustomerID: "cust_list_" + strconv.Itoa(i),
+			TotalSlots:       5,
+			UsedSlots:        0,
+			AmountDue:        decimal.Zero,
+			Status:           stripe.SubscriptionStatusActive,
+		})
+	}
+
+	subs, total, err := testSvc.GetAllSubscriptions(0, 2)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, total)
+	assert.Len(t, subs, 2)
+}
+
+func TestGetAllSubscriptions_DefaultsLimit(t *testing.T) {
+	clearZonesTables()
+
+	for i := 0; i < 3; i++ {
+		createZoneSubscription(t, &models.ZonesSubscriptions{
+			UserID:           uuid.New(),
+			StripeCustomerID: "cust_default_" + strconv.Itoa(i),
+			TotalSlots:       5,
+			UsedSlots:        0,
+			AmountDue:        decimal.Zero,
+			Status:           stripe.SubscriptionStatusActive,
+		})
+	}
+
+	subs, total, err := testSvc.GetAllSubscriptions(0, 0)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, total)
+	assert.Len(t, subs, 3)
+}
+
+func TestGetAllSubscriptions_DefaultsOffset(t *testing.T) {
+	clearZonesTables()
+
+	createZoneSubscription(t, &models.ZonesSubscriptions{
+		UserID:           uuid.New(),
+		StripeCustomerID: "cust_offset",
+		TotalSlots:       5,
+		UsedSlots:        0,
+		AmountDue:        decimal.Zero,
+		Status:           stripe.SubscriptionStatusActive,
+	})
+
+	subs, total, err := testSvc.GetAllSubscriptions(-5, 10)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+	assert.Len(t, subs, 1)
+}
+
+func TestGetAllSubscriptions_Empty(t *testing.T) {
+	clearZonesTables()
+
+	subs, total, err := testSvc.GetAllSubscriptions(0, 10)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, total)
+	assert.Empty(t, subs)
+}

--- a/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
+++ b/internal/payment-service/services/zones-subscriptions/zones_subscriptions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/v85"
 )
 
@@ -190,24 +191,7 @@ func TestStopAllJobs_ResetsSlots(t *testing.T) {
 	clearZonesTables()
 	userID := uuid.New()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		expectedPath := "/world/internal/users/" + userID.String() + "/stop-jobs"
-		if r.URL.Path != expectedPath {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	parsed, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatalf("failed to parse server url: %v", err)
-	}
-	port, err := strconv.Atoi(parsed.Port())
-	if err != nil {
-		t.Fatalf("failed to parse server port: %v", err)
-	}
-	testConf.Server.Port = port
+	setupStopJobsServer(t, userID)
 
 	createZoneSubscription(t, &models.ZonesSubscriptions{
 		UserID:           userID,
@@ -219,7 +203,7 @@ func TestStopAllJobs_ResetsSlots(t *testing.T) {
 	})
 
 	sub, _ := testRepo.GetByUserID(userID)
-	err = testSvc.stopAllJobs(sub)
+	err := testSvc.stopAllJobs(sub)
 	assert.NoError(t, err)
 	updated, _ := testRepo.GetByUserID(userID)
 	assert.Equal(t, 0, updated.UsedSlots)
@@ -238,6 +222,37 @@ func TestNextBillingDate_AnchorInFuture(t *testing.T) {
 
 	next := testSvc.nextBillingDate()
 	assert.True(t, next.After(time.Now().UTC()))
+}
+
+func setupStopJobsServer(t *testing.T, userID uuid.UUID) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/world/internal/users/" + userID.String() + "/stop-jobs"
+		if r.URL.Path != expectedPath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse server url: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("failed to parse server port: %v", err)
+	}
+
+	originalPort := testConf.Server.Port
+	testConf.Server.Port = port
+
+	t.Cleanup(func() {
+		server.Close()
+		testConf.Server.Port = originalPort
+	})
 }
 
 func TestAdminCreateSubscription_InvalidSlots(t *testing.T) {
@@ -470,6 +485,8 @@ func TestAdminCancelSubscription_AdminGranted_Immediate(t *testing.T) {
 	clearZonesTables()
 	userID := uuid.New()
 
+	setupStopJobsServer(t, userID)
+
 	createZoneSubscription(t, &models.ZonesSubscriptions{
 		UserID:           userID,
 		StripeCustomerID: "cust_admin_cancel",
@@ -481,8 +498,8 @@ func TestAdminCancelSubscription_AdminGranted_Immediate(t *testing.T) {
 	})
 
 	sub, err := testSvc.AdminCancelSubscription(userID)
-	assert.NoError(t, err)
-	assert.NotNil(t, sub)
+	require.NoError(t, err)
+	require.NotNil(t, sub)
 	assert.Equal(t, stripe.SubscriptionStatusCanceled, sub.Status)
 	assert.False(t, sub.IsAdminGranted)
 	assert.Equal(t, 0, sub.TotalSlots)

--- a/migrations/payment-service/07_add_admin_granted.down.sql
+++ b/migrations/payment-service/07_add_admin_granted.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE zones_subscriptions
+  DROP COLUMN IF EXISTS is_admin_granted;
+
+COMMIT;

--- a/migrations/payment-service/07_add_admin_granted.up.sql
+++ b/migrations/payment-service/07_add_admin_granted.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE zones_subscriptions
+  ADD COLUMN IF NOT EXISTS is_admin_granted BOOLEAN NOT NULL DEFAULT false;
+
+COMMIT;

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3117,6 +3117,243 @@ const docTemplate = `{
                 }
             }
         },
+        "/subscriptions/admin/users": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of every subscription (comp and Stripe alike), admin only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin list all subscriptions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Pagination limit",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.AdminSubscriptionsListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/subscriptions/admin/users/{user_id}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Grants a free/comp subscription to a user, bypassing Stripe.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin grant comp subscription",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Admin create subscription payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.AdminCreateSubscriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cancels a user's subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin cancel subscription",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/subscriptions/admin/users/{user_id}/slots": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates the total slots of a user's subscription, bypassing normal user-flow restrictions (e.g. allowed even if pending cancellation).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin update subscription slots",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update subscription slots payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UpdateSubscriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/subscriptions/checkout": {
             "post": {
                 "security": [
@@ -4627,6 +4864,61 @@ const docTemplate = `{
             "properties": {
                 "category_name": {
                     "type": "string"
+                }
+            }
+        },
+        "dtos.AdminCreateSubscriptionRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "slots"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "slots": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dtos.AdminSubscriptionResponse": {
+            "type": "object",
+            "properties": {
+                "amount_due": {
+                    "type": "number"
+                },
+                "is_admin_granted": {
+                    "type": "boolean"
+                },
+                "next_billing_date": {
+                    "type": "string"
+                },
+                "slots": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "used_slots": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "dtos.AdminSubscriptionsListResponse": {
+            "type": "object",
+            "properties": {
+                "subscriptions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dtos.AdminSubscriptionResponse"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
                 }
             }
         },

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3110,6 +3110,243 @@
                 }
             }
         },
+        "/subscriptions/admin/users": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of every subscription (comp and Stripe alike), admin only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin list all subscriptions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Pagination limit",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.AdminSubscriptionsListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/subscriptions/admin/users/{user_id}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Grants a free/comp subscription to a user, bypassing Stripe.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin grant comp subscription",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Admin create subscription payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.AdminCreateSubscriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cancels a user's subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin cancel subscription",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/subscriptions/admin/users/{user_id}/slots": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates the total slots of a user's subscription, bypassing normal user-flow restrictions (e.g. allowed even if pending cancellation).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payment-service-subscriptions"
+                ],
+                "summary": "Admin update subscription slots",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update subscription slots payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UpdateSubscriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.SubscriptionStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/subscriptions/checkout": {
             "post": {
                 "security": [
@@ -4620,6 +4857,61 @@
             "properties": {
                 "category_name": {
                     "type": "string"
+                }
+            }
+        },
+        "dtos.AdminCreateSubscriptionRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "slots"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "slots": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dtos.AdminSubscriptionResponse": {
+            "type": "object",
+            "properties": {
+                "amount_due": {
+                    "type": "number"
+                },
+                "is_admin_granted": {
+                    "type": "boolean"
+                },
+                "next_billing_date": {
+                    "type": "string"
+                },
+                "slots": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "used_slots": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "dtos.AdminSubscriptionsListResponse": {
+            "type": "object",
+            "properties": {
+                "subscriptions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dtos.AdminSubscriptionResponse"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
                 }
             }
         },

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -7,6 +7,42 @@ definitions:
     required:
     - category_name
     type: object
+  dtos.AdminCreateSubscriptionRequest:
+    properties:
+      email:
+        type: string
+      slots:
+        type: integer
+    required:
+    - email
+    - slots
+    type: object
+  dtos.AdminSubscriptionResponse:
+    properties:
+      amount_due:
+        type: number
+      is_admin_granted:
+        type: boolean
+      next_billing_date:
+        type: string
+      slots:
+        type: integer
+      status:
+        type: string
+      used_slots:
+        type: integer
+      user_id:
+        type: string
+    type: object
+  dtos.AdminSubscriptionsListResponse:
+    properties:
+      subscriptions:
+        items:
+          $ref: '#/definitions/dtos.AdminSubscriptionResponse'
+        type: array
+      total_count:
+        type: integer
+    type: object
   dtos.CharacterInfoResponse:
     properties:
       category_sprites:
@@ -2692,6 +2728,160 @@ paths:
       security:
       - BearerAuth: []
       summary: Cancel subscription
+      tags:
+      - payment-service-subscriptions
+  /subscriptions/admin/users:
+    get:
+      description: Returns a paginated list of every subscription (comp and Stripe
+        alike), admin only.
+      parameters:
+      - default: 0
+        description: Pagination offset
+        in: query
+        name: offset
+        type: integer
+      - default: 50
+        description: Pagination limit
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dtos.AdminSubscriptionsListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Admin list all subscriptions
+      tags:
+      - payment-service-subscriptions
+  /subscriptions/admin/users/{user_id}:
+    delete:
+      description: Cancels a user's subscription
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dtos.SubscriptionStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Admin cancel subscription
+      tags:
+      - payment-service-subscriptions
+    post:
+      consumes:
+      - application/json
+      description: Grants a free/comp subscription to a user, bypassing Stripe.
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: string
+      - description: Admin create subscription payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.AdminCreateSubscriptionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dtos.SubscriptionStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Admin grant comp subscription
+      tags:
+      - payment-service-subscriptions
+  /subscriptions/admin/users/{user_id}/slots:
+    put:
+      consumes:
+      - application/json
+      description: Updates the total slots of a user's subscription, bypassing normal
+        user-flow restrictions (e.g. allowed even if pending cancellation).
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: string
+      - description: Update subscription slots payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.UpdateSubscriptionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dtos.SubscriptionStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Admin update subscription slots
       tags:
       - payment-service-subscriptions
   /subscriptions/checkout:


### PR DESCRIPTION
## Changes:

* Added `GET /subscriptions/admin/users` endpoint (admin-only) returning a paginated list of all subscriptions (complimentary and Stripe-based).
* Added `POST /subscriptions/admin/users/{user_id}` endpoint (admin-only) to grant a complimentary subscription bypassing Stripe, reusing inactive records when available.
* Added `PUT /subscriptions/admin/users/{user_id}/slots` endpoint (admin-only) to update total slots of an admin-granted subscription, with validation against used slots.
* Added `DELETE /subscriptions/admin/users/{user_id}` endpoint (admin-only) to cancel a subscription; complimentary subscriptions are cancelled immediately, Stripe subscriptions are scheduled for end-of-period.
* Added `is_admin_granted` column to `zones_subscriptions` table via migration to distinguish complimentary subscriptions.
* Added `AdminCreateSubscriptionRequest`, `AdminSubscriptionResponse`, and `AdminSubscriptionsListResponse` DTOs for the new endpoints.
* Added `GetAll` repository method to support paginated subscription listing.
* Added service methods `GetAllSubscriptions`, `AdminCreateSubscription`, `AdminUpdateSlots`, and `AdminCancelSubscription` with domain validations (active status, slot limits, admin-granted guard).
* `AdminUpdateSlots` now rejects updates for non-admin-granted subscriptions and prevents setting slots below the currently used amount.
* Updated router to register admin routes protected by `AdminCheckMiddleware`.
* Updated Swagger documentation to reflect all new admin endpoints.
* Added unit tests